### PR TITLE
[feat] 스쿼드 상세조회 코멘트 삭제 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/exception/ErrorCode.java
+++ b/src/main/java/com/nexus/sion/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
   PROJECT_SQUAD_NOT_FOUND("40001", "해당 프로젝트에 스쿼드가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
   SQUAD_DETAIL_NOT_FOUND("40002", "스쿼드 상세 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   COMMENT_CONTENT_EMPTY("40003", "코멘트 내용(content)은 공백일 수 없습니다.", HttpStatus.BAD_REQUEST),
-  PROJECT_CODE_INVALID("40003", "유효하지 않은 프로젝트 코드입니다.", HttpStatus.BAD_REQUEST);
+  PROJECT_CODE_INVALID("40004", "유효하지 않은 프로젝트 코드입니다.", HttpStatus.BAD_REQUEST),
+  COMMENT_NOT_FOUND("40005", "존재하지 않는 코멘트입니다.", HttpStatus.NOT_FOUND),
+  INVALID_COMMENT_ACCESS("40006", "해당 스쿼드의 코멘트가 아닙니다.", HttpStatus.FORBIDDEN);
 
   // techstack
 

--- a/src/main/java/com/nexus/sion/feature/squad/command/application/controller/SquadCommentCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/application/controller/SquadCommentCommandController.java
@@ -23,4 +23,10 @@ public class SquadCommentCommandController {
     squadCommentCommandService.registerComment(squadCode, request); // 👈 squadCode 따로 전달
     return ResponseEntity.ok().build();
   }
+
+  @DeleteMapping("/{squadCode}/comments/{commentId}")
+  public ResponseEntity<Void> delete(@PathVariable String squadCode, @PathVariable Long commentId) {
+    squadCommentCommandService.deleteComment(squadCode, commentId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandService.java
@@ -19,7 +19,6 @@ public class SquadCommentCommandService {
   private final SquadCommentRepository squadCommentRepository;
 
   public void registerComment(String squadCode, SquadCommentRegisterRequest request) {
-    // ✅ content가 null이거나 공백이면 예외 발생
     if (request.getContent() == null || request.getContent().trim().isEmpty()) {
       throw new BusinessException(ErrorCode.COMMENT_CONTENT_EMPTY);
     }
@@ -33,5 +32,18 @@ public class SquadCommentCommandService {
             .build();
 
     squadCommentRepository.save(comment);
+  }
+
+  public void deleteComment(String squadCode, Long commentId) {
+    SquadComment comment =
+        squadCommentRepository
+            .findById(commentId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+    if (!comment.getSquadCode().equals(squadCode)) {
+      throw new BusinessException(ErrorCode.INVALID_COMMENT_ACCESS);
+    }
+
+    squadCommentRepository.delete(comment);
   }
 }

--- a/src/test/java/com/nexus/sion/feature/squad/command/SquadCommentIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/SquadCommentIntegrationTest.java
@@ -1,7 +1,10 @@
 package com.nexus.sion.feature.squad.command;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexus.sion.feature.squad.command.application.dto.request.SquadCommentRegisterRequest;
+import com.nexus.sion.feature.squad.command.domain.aggregate.entity.SquadComment;
 import com.nexus.sion.feature.squad.command.repository.SquadCommentRepository;
 
 @SpringBootTest
@@ -56,5 +60,46 @@ class SquadCommentCommandIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @DisplayName("코멘트 삭제에 성공한다")
+  void deleteComment_success() throws Exception {
+    // given
+    SquadComment comment =
+        SquadComment.builder()
+            .squadCode("ha_1_1_1")
+            .employeeIdentificationNumber("EMP001")
+            .content("삭제 테스트 코멘트입니다.")
+            .createdAt(LocalDateTime.now())
+            .build();
+    squadCommentRepository.saveAndFlush(comment);
+
+    // when & then
+    mockMvc
+        .perform(
+            delete(
+                "/api/v1/squads/{squadCode}/comments/{commentId}",
+                comment.getSquadCode(),
+                comment.getId()))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  @DisplayName("코멘트가 해당 스쿼드에 속하지 않으면 삭제에 실패한다")
+  void deleteComment_fail_whenSquadCodeMismatch() throws Exception {
+    SquadComment comment =
+        SquadComment.builder()
+            .squadCode("ha_1_1_1")
+            .employeeIdentificationNumber("EMP001")
+            .content("스쿼드 불일치 테스트")
+            .createdAt(LocalDateTime.now())
+            .build();
+    squadCommentRepository.saveAndFlush(comment);
+
+    // 다른 squadCode로 요청
+    mockMvc
+        .perform(delete("/api/v1/squads/{squadCode}/comments/{commentId}", "다른코드", comment.getId()))
+        .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandServiceTest.java
@@ -91,4 +91,27 @@ class SquadCommentCommandServiceTest {
 
     verify(squadCommentRepository, never()).delete(any());
   }
+
+  @Test
+  @DisplayName("코멘트가 다른 스쿼드에 속할 경우 삭제 시 예외가 발생한다")
+  void deleteComment_fail_whenSquadCodeMismatches() {
+    // given
+    String requestSquadCode = "ha_1_1_1";
+    Long commentId = 1L;
+    SquadComment comment = SquadComment.builder()
+            .id(commentId)
+            .squadCode("another_squad_code")
+            .employeeIdentificationNumber("EMM001")
+            .content("테스트")
+            .build();
+
+    when(squadCommentRepository.findById(commentId)).thenReturn(java.util.Optional.of(comment));
+
+    // when & then
+    assertThatThrownBy(() -> squadCommentCommandService.deleteComment(requestSquadCode, commentId))
+            .isInstanceOf(BusinessException.class)
+            .hasMessageContaining(ErrorCode.INVALID_COMMENT_ACCESS.getMessage());
+
+    verify(squadCommentRepository, never()).delete(any(SquadComment.class));
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommentCommandServiceTest.java
@@ -52,4 +52,43 @@ class SquadCommentCommandServiceTest {
 
     verify(squadCommentRepository, never()).save(any());
   }
+
+  @Test
+  @DisplayName("스쿼드 코멘트를 정상적으로 삭제한다")
+  void deleteComment_success() {
+    // given
+    String squadCode = "ha_1_1_1";
+    Long commentId = 1L;
+    SquadComment comment =
+        SquadComment.builder()
+            .id(commentId)
+            .squadCode(squadCode)
+            .employeeIdentificationNumber("EMM001")
+            .content("삭제 테스트")
+            .build();
+
+    when(squadCommentRepository.findById(commentId)).thenReturn(java.util.Optional.of(comment));
+
+    // when
+    squadCommentCommandService.deleteComment(squadCode, commentId);
+
+    // then
+    verify(squadCommentRepository, times(1)).delete(comment);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 코멘트 삭제 시 예외 발생")
+  void deleteComment_fail_whenCommentNotFound() {
+    // given
+    Long commentId = 999L;
+    String squadCode = "ha_1_1_1";
+    when(squadCommentRepository.findById(commentId)).thenReturn(java.util.Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> squadCommentCommandService.deleteComment(squadCode, commentId))
+        .isInstanceOf(BusinessException.class)
+        .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+
+    verify(squadCommentRepository, never()).delete(any());
+  }
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #38 


<br>

## 🪐 작업 내용
스쿼드 코멘트 삭제 API 구현
SquadCommentCommandService에 삭제 메서드 추가
삭제 성공/실패에 대한 통합 테스트 (SquadCommentCommandIntegrationTest)
서비스 단위 테스트 (SquadCommentCommandServiceTest)

<br>

## ✅ 체크리스트
- [x]  기능 구현
- [x]  service mock 단위 테스트
- [x]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
