### PR TITLE
[feat] 직급, 부서 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Position.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Position.java
@@ -7,7 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "position")
+@Table(name = "`position`")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/DepartmentQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/DepartmentQueryController.java
@@ -1,0 +1,26 @@
+package com.nexus.sion.feature.member.query.controller;
+
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.service.DepartmentQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/departments")
+public class DepartmentQueryController {
+
+    private final DepartmentQueryService departmentQueryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getAllDepartments() {
+        List<DepartmentResponse> departments = departmentQueryService.getDepartments();
+        return ResponseEntity.ok(ApiResponse.success(departments));
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/DepartmentQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/DepartmentQueryController.java
@@ -1,26 +1,28 @@
 package com.nexus.sion.feature.member.query.controller;
 
-import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
-import com.nexus.sion.feature.member.query.service.DepartmentQueryService;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.service.DepartmentQueryService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/departments")
 public class DepartmentQueryController {
 
-    private final DepartmentQueryService departmentQueryService;
+  private final DepartmentQueryService departmentQueryService;
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getAllDepartments() {
-        List<DepartmentResponse> departments = departmentQueryService.getDepartments();
-        return ResponseEntity.ok(ApiResponse.success(departments));
-    }
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<DepartmentResponse>>> getAllDepartments() {
+    List<DepartmentResponse> departments = departmentQueryService.getDepartments();
+    return ResponseEntity.ok(ApiResponse.success(departments));
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/PositionQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/PositionQueryController.java
@@ -1,0 +1,26 @@
+package com.nexus.sion.feature.member.query.controller;
+
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.service.PositionQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/positions")
+@RequiredArgsConstructor
+public class PositionQueryController {
+
+    private final PositionQueryService positionQueryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PositionResponse>>> getAllPositions() {
+        List<PositionResponse> positions = positionQueryService.getPositions();
+        return ResponseEntity.ok(ApiResponse.success(positions));
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/PositionQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/PositionQueryController.java
@@ -1,26 +1,28 @@
 package com.nexus.sion.feature.member.query.controller;
 
-import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
-import com.nexus.sion.feature.member.query.service.PositionQueryService;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.service.PositionQueryService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/positions")
 @RequiredArgsConstructor
 public class PositionQueryController {
 
-    private final PositionQueryService positionQueryService;
+  private final PositionQueryService positionQueryService;
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<PositionResponse>>> getAllPositions() {
-        List<PositionResponse> positions = positionQueryService.getPositions();
-        return ResponseEntity.ok(ApiResponse.success(positions));
-    }
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PositionResponse>>> getAllPositions() {
+    List<PositionResponse> positions = positionQueryService.getPositions();
+    return ResponseEntity.ok(ApiResponse.success(positions));
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
@@ -1,5 +1,3 @@
 package com.nexus.sion.feature.member.query.dto.response;
 
-public record DepartmentResponse(
-        String departmentName
-) {}
+public record DepartmentResponse(String departmentName) {}

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
@@ -1,0 +1,9 @@
+package com.nexus.sion.feature.member.query.dto.response;
+
+import java.time.LocalDateTime;
+
+public record DepartmentResponse(
+        String departmentName,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DepartmentResponse.java
@@ -1,9 +1,5 @@
 package com.nexus.sion.feature.member.query.dto.response;
 
-import java.time.LocalDateTime;
-
 public record DepartmentResponse(
-        String departmentName,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        String departmentName
 ) {}

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/PositionResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/PositionResponse.java
@@ -1,5 +1,3 @@
 package com.nexus.sion.feature.member.query.dto.response;
 
-public record PositionResponse(
-        String positionName
-) {}
+public record PositionResponse(String positionName) {}

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/PositionResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/PositionResponse.java
@@ -1,0 +1,5 @@
+package com.nexus.sion.feature.member.query.dto.response;
+
+public record PositionResponse(
+        String positionName
+) {}

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
@@ -1,25 +1,25 @@
 package com.nexus.sion.feature.member.query.repository;
 
-import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
-import lombok.RequiredArgsConstructor;
-import org.jooq.DSLContext;
-import org.springframework.stereotype.Repository;
+import static com.example.jooq.generated.tables.Department.DEPARTMENT;
 
 import java.util.List;
 
-import static com.example.jooq.generated.tables.Department.DEPARTMENT;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class DepartmentQueryRepository {
 
-    private final DSLContext dsl;
+  private final DSLContext dsl;
 
-    public List<DepartmentResponse> findAllDepartments() {
-        return dsl.select(
-                        DEPARTMENT.DEPARTMENT_NAME
-                )
-                .from(DEPARTMENT)
-                .fetchInto(DepartmentResponse.class);
-    }
+  public List<DepartmentResponse> findAllDepartments() {
+    return dsl.select(DEPARTMENT.DEPARTMENT_NAME)
+        .from(DEPARTMENT)
+        .fetchInto(DepartmentResponse.class);
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
@@ -17,9 +17,7 @@ public class DepartmentQueryRepository {
 
     public List<DepartmentResponse> findAllDepartments() {
         return dsl.select(
-                        DEPARTMENT.DEPARTMENT_NAME,
-                        DEPARTMENT.CREATE_AT,
-                        DEPARTMENT.UPDATED_AT
+                        DEPARTMENT.DEPARTMENT_NAME
                 )
                 .from(DEPARTMENT)
                 .fetchInto(DepartmentResponse.class);

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/DepartmentQueryRepository.java
@@ -1,0 +1,27 @@
+package com.nexus.sion.feature.member.query.repository;
+
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.jooq.generated.tables.Department.DEPARTMENT;
+
+@Repository
+@RequiredArgsConstructor
+public class DepartmentQueryRepository {
+
+    private final DSLContext dsl;
+
+    public List<DepartmentResponse> findAllDepartments() {
+        return dsl.select(
+                        DEPARTMENT.DEPARTMENT_NAME,
+                        DEPARTMENT.CREATE_AT,
+                        DEPARTMENT.UPDATED_AT
+                )
+                .from(DEPARTMENT)
+                .fetchInto(DepartmentResponse.class);
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/PositionQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/PositionQueryRepository.java
@@ -1,26 +1,26 @@
 package com.nexus.sion.feature.member.query.repository;
 
-
-import com.example.jooq.generated.tables.Position;
-import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
-import lombok.RequiredArgsConstructor;
-import org.jooq.DSLContext;
-import org.springframework.stereotype.Repository;
+import static com.example.jooq.generated.tables.Position.POSITION;
 
 import java.util.List;
 
-import static com.example.jooq.generated.tables.Position.POSITION;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class PositionQueryRepository {
 
-    private final DSLContext dsl;
+  private final DSLContext dsl;
 
-    public List<PositionResponse> findAllPositions() {
-        return dsl.select(POSITION.POSITION_NAME)
-                .from(POSITION)
-                .orderBy(POSITION.POSITION_NAME.asc())
-                .fetchInto(PositionResponse.class);
-    }
+  public List<PositionResponse> findAllPositions() {
+    return dsl.select(POSITION.POSITION_NAME)
+        .from(POSITION)
+        .orderBy(POSITION.POSITION_NAME.asc())
+        .fetchInto(PositionResponse.class);
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/PositionQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/PositionQueryRepository.java
@@ -1,0 +1,26 @@
+package com.nexus.sion.feature.member.query.repository;
+
+
+import com.example.jooq.generated.tables.Position;
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.jooq.generated.tables.Position.POSITION;
+
+@Repository
+@RequiredArgsConstructor
+public class PositionQueryRepository {
+
+    private final DSLContext dsl;
+
+    public List<PositionResponse> findAllPositions() {
+        return dsl.select(POSITION.POSITION_NAME)
+                .from(POSITION)
+                .orderBy(POSITION.POSITION_NAME.asc())
+                .fetchInto(PositionResponse.class);
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/service/DepartmentQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/DepartmentQueryService.java
@@ -1,19 +1,21 @@
 package com.nexus.sion.feature.member.query.service;
 
-import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
-import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class DepartmentQueryService {
 
-    private final DepartmentQueryRepository departmentQueryRepository;
+  private final DepartmentQueryRepository departmentQueryRepository;
 
-    public List<DepartmentResponse> getDepartments() {
-        return departmentQueryRepository.findAllDepartments();
-    }
+  public List<DepartmentResponse> getDepartments() {
+    return departmentQueryRepository.findAllDepartments();
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/DepartmentQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/DepartmentQueryService.java
@@ -1,0 +1,19 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentQueryService {
+
+    private final DepartmentQueryRepository departmentQueryRepository;
+
+    public List<DepartmentResponse> getDepartments() {
+        return departmentQueryRepository.findAllDepartments();
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/service/PositionQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/PositionQueryService.java
@@ -1,0 +1,19 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PositionQueryService {
+
+    private final PositionQueryRepository positionQueryRepository;
+
+    public List<PositionResponse> getPositions() {
+        return positionQueryRepository.findAllPositions();
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/service/PositionQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/PositionQueryService.java
@@ -1,19 +1,21 @@
 package com.nexus.sion.feature.member.query.service;
 
-import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
-import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class PositionQueryService {
 
-    private final PositionQueryRepository positionQueryRepository;
+  private final PositionQueryRepository positionQueryRepository;
 
-    public List<PositionResponse> getPositions() {
-        return positionQueryRepository.findAllPositions();
-    }
+  public List<PositionResponse> getPositions() {
+    return positionQueryRepository.findAllPositions();
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.nexus.sion.feature.member.query;
+
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Department;
+import com.nexus.sion.feature.member.command.domain.repository.DepartmentRepository;
+import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
+import com.nexus.sion.feature.member.command.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class DepartmentQueryIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DepartmentRepository departmentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DeveloperTechStackRepository developerTechStackRepository;
+
+    @BeforeEach
+    void setUp() {
+        developerTechStackRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        if (!departmentRepository.existsById("백엔드팀")) {
+            departmentRepository.save(
+                    Department.builder()
+                            .departmentName("백엔드팀")
+                            .build()
+            );
+        }
+
+        departmentRepository.flush();
+    }
+
+    @Test
+    @DisplayName("부서 목록 조회 API - 응답에 '백엔드팀' 포함 확인")
+    void getAllDepartments_success_containsExpectedDepartments() throws Exception {
+        mockMvc.perform(get("/api/v1/departments")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[*].departmentName",
+                        hasItems("백엔드팀")));
+    }
+}

--- a/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
@@ -1,10 +1,11 @@
 package com.nexus.sion.feature.member.query;
 
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Department;
-import com.nexus.sion.feature.member.command.domain.repository.DepartmentRepository;
-import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
-import com.nexus.sion.feature.member.command.repository.MemberRepository;
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import jakarta.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,49 +15,41 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Department;
+import com.nexus.sion.feature.member.command.domain.repository.DepartmentRepository;
+import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
+import com.nexus.sion.feature.member.command.repository.MemberRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 class DepartmentQueryIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private DepartmentRepository departmentRepository;
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private DeveloperTechStackRepository developerTechStackRepository;
+  @Autowired private DepartmentRepository departmentRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private DeveloperTechStackRepository developerTechStackRepository;
 
-    @BeforeEach
-    void setUp() {
-        developerTechStackRepository.deleteAll();
-        memberRepository.deleteAll();
+  @BeforeEach
+  void setUp() {
+    developerTechStackRepository.deleteAll();
+    memberRepository.deleteAll();
 
-        if (!departmentRepository.existsById("백엔드팀")) {
-            departmentRepository.save(
-                    Department.builder()
-                            .departmentName("백엔드팀")
-                            .build()
-            );
-        }
-
-        departmentRepository.flush();
+    if (!departmentRepository.existsById("백엔드팀")) {
+      departmentRepository.save(Department.builder().departmentName("백엔드팀").build());
     }
 
-    @Test
-    @DisplayName("부서 목록 조회 API - 응답에 '백엔드팀' 포함 확인")
-    void getAllDepartments_success_containsExpectedDepartments() throws Exception {
-        mockMvc.perform(get("/api/v1/departments")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[*].departmentName",
-                        hasItems("백엔드팀")));
-    }
+    departmentRepository.flush();
+  }
+
+  @Test
+  @DisplayName("부서 목록 조회 API - 응답에 '백엔드팀' 포함 확인")
+  void getAllDepartments_success_containsExpectedDepartments() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/departments").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data[*].departmentName", hasItems("백엔드팀")));
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/DepartmentQueryIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/nexus/sion/feature/member/query/PositionQueryIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/PositionQueryIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.nexus.sion.feature.member.query;
+
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Department;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Position;
+import com.nexus.sion.feature.member.command.domain.repository.DepartmentRepository;
+import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
+import com.nexus.sion.feature.member.command.domain.repository.PositionRepository;
+import com.nexus.sion.feature.member.command.repository.MemberRepository;
+import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class PositionQueryIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private DeveloperTechStackRepository developerTechStackRepository;
+    @Autowired
+    private PositionRepository positionRepository;
+
+    @BeforeEach
+    void setUp() {
+        developerTechStackRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        if (!positionRepository.existsById("PM")) {
+            positionRepository.save(
+                    Position.builder()
+                            .positionName("PM")
+                            .build()
+            );
+        }
+
+        positionRepository.flush();
+    }
+
+    @Test
+    @DisplayName("직급 목록 조회 API - 응답에 'PM' 포함 확인")
+    void getAllPositions_success_containsExpectedPositions() throws Exception {
+        mockMvc.perform(get("/api/v1/positions")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[*].positionName",
+                        hasItems("PM")));
+    }
+}

--- a/src/test/java/com/nexus/sion/feature/member/query/PositionQueryIntegrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/PositionQueryIntegrationTest.java
@@ -1,13 +1,11 @@
 package com.nexus.sion.feature.member.query;
 
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Department;
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Position;
-import com.nexus.sion.feature.member.command.domain.repository.DepartmentRepository;
-import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
-import com.nexus.sion.feature.member.command.domain.repository.PositionRepository;
-import com.nexus.sion.feature.member.command.repository.MemberRepository;
-import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+import static org.hamcrest.Matchers.hasItems;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import jakarta.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,49 +15,41 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Position;
+import com.nexus.sion.feature.member.command.domain.repository.DeveloperTechStackRepository;
+import com.nexus.sion.feature.member.command.domain.repository.PositionRepository;
+import com.nexus.sion.feature.member.command.repository.MemberRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
 class PositionQueryIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  @Autowired private MockMvc mockMvc;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private DeveloperTechStackRepository developerTechStackRepository;
-    @Autowired
-    private PositionRepository positionRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private DeveloperTechStackRepository developerTechStackRepository;
+  @Autowired private PositionRepository positionRepository;
 
-    @BeforeEach
-    void setUp() {
-        developerTechStackRepository.deleteAll();
-        memberRepository.deleteAll();
+  @BeforeEach
+  void setUp() {
+    developerTechStackRepository.deleteAll();
+    memberRepository.deleteAll();
 
-        if (!positionRepository.existsById("PM")) {
-            positionRepository.save(
-                    Position.builder()
-                            .positionName("PM")
-                            .build()
-            );
-        }
-
-        positionRepository.flush();
+    if (!positionRepository.existsById("PM")) {
+      positionRepository.save(Position.builder().positionName("PM").build());
     }
 
-    @Test
-    @DisplayName("직급 목록 조회 API - 응답에 'PM' 포함 확인")
-    void getAllPositions_success_containsExpectedPositions() throws Exception {
-        mockMvc.perform(get("/api/v1/positions")
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[*].positionName",
-                        hasItems("PM")));
-    }
+    positionRepository.flush();
+  }
+
+  @Test
+  @DisplayName("직급 목록 조회 API - 응답에 'PM' 포함 확인")
+  void getAllPositions_success_containsExpectedPositions() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/positions").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data[*].positionName", hasItems("PM")));
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
@@ -20,7 +20,8 @@ class DepartmentQueryServiceTest {
 
   @InjectMocks private DepartmentQueryService departmentQueryService;
 
-  public DepartmentQueryServiceTest() {
+  @BeforeEach
+  void setUp() {
     openMocks(this);
   }
 

--- a/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
@@ -1,0 +1,48 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+class DepartmentQueryServiceTest {
+
+    @Mock
+    private DepartmentQueryRepository departmentQueryRepository;
+
+    @InjectMocks
+    private DepartmentQueryService departmentQueryService;
+
+    public DepartmentQueryServiceTest() {
+        openMocks(this);
+    }
+
+    @Test
+    @DisplayName("부서 목록 조회 - 성공")
+    void getDepartments_success() {
+        // given
+        List<DepartmentResponse> mockResult = List.of(
+                new DepartmentResponse("개발팀"),
+                new DepartmentResponse("기획팀"),
+                new DepartmentResponse("디자인팀")
+        );
+
+        when(departmentQueryRepository.findAllDepartments()).thenReturn(mockResult);
+
+        // when
+        List<DepartmentResponse> result = departmentQueryService.getDepartments();
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting("departmentName")
+                .containsExactly("개발팀", "기획팀", "디자인팀");
+    }
+}

--- a/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/service/DepartmentQueryServiceTest.java
@@ -1,48 +1,46 @@
 package com.nexus.sion.feature.member.query.service;
 
-import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
-import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
+import com.nexus.sion.feature.member.query.dto.response.DepartmentResponse;
+import com.nexus.sion.feature.member.query.repository.DepartmentQueryRepository;
 
 class DepartmentQueryServiceTest {
 
-    @Mock
-    private DepartmentQueryRepository departmentQueryRepository;
+  @Mock private DepartmentQueryRepository departmentQueryRepository;
 
-    @InjectMocks
-    private DepartmentQueryService departmentQueryService;
+  @InjectMocks private DepartmentQueryService departmentQueryService;
 
-    public DepartmentQueryServiceTest() {
-        openMocks(this);
-    }
+  public DepartmentQueryServiceTest() {
+    openMocks(this);
+  }
 
-    @Test
-    @DisplayName("부서 목록 조회 - 성공")
-    void getDepartments_success() {
-        // given
-        List<DepartmentResponse> mockResult = List.of(
-                new DepartmentResponse("개발팀"),
-                new DepartmentResponse("기획팀"),
-                new DepartmentResponse("디자인팀")
-        );
+  @Test
+  @DisplayName("부서 목록 조회 - 성공")
+  void getDepartments_success() {
+    // given
+    List<DepartmentResponse> mockResult =
+        List.of(
+            new DepartmentResponse("개발팀"),
+            new DepartmentResponse("기획팀"),
+            new DepartmentResponse("디자인팀"));
 
-        when(departmentQueryRepository.findAllDepartments()).thenReturn(mockResult);
+    when(departmentQueryRepository.findAllDepartments()).thenReturn(mockResult);
 
-        // when
-        List<DepartmentResponse> result = departmentQueryService.getDepartments();
+    // when
+    List<DepartmentResponse> result = departmentQueryService.getDepartments();
 
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result).extracting("departmentName")
-                .containsExactly("개발팀", "기획팀", "디자인팀");
-    }
+    // then
+    assertThat(result).hasSize(3);
+    assertThat(result).extracting("departmentName").containsExactly("개발팀", "기획팀", "디자인팀");
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/member/query/service/PositionQueryServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/service/PositionQueryServiceTest.java
@@ -1,50 +1,48 @@
 package com.nexus.sion.feature.member.query.service;
 
-import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
-import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
 
 class PositionQueryServiceTest {
 
-    @Mock
-    private PositionQueryRepository positionQueryRepository;
+  @Mock private PositionQueryRepository positionQueryRepository;
 
-    @InjectMocks
-    private PositionQueryService positionQueryService;
+  @InjectMocks private PositionQueryService positionQueryService;
 
-    @BeforeEach
-    void setUp() {
-        openMocks(this);
-    }
+  @BeforeEach
+  void setUp() {
+    openMocks(this);
+  }
 
-    @Test
-    @DisplayName("직급 목록 조회 - 성공")
-    void getPositions_success() {
-        // given
-        List<PositionResponse> mockResult = List.of(
-                new PositionResponse("백엔드 개발자"),
-                new PositionResponse("프론트엔드 개발자"),
-                new PositionResponse("PM")
-        );
+  @Test
+  @DisplayName("직급 목록 조회 - 성공")
+  void getPositions_success() {
+    // given
+    List<PositionResponse> mockResult =
+        List.of(
+            new PositionResponse("백엔드 개발자"),
+            new PositionResponse("프론트엔드 개발자"),
+            new PositionResponse("PM"));
 
-        when(positionQueryRepository.findAllPositions()).thenReturn(mockResult);
+    when(positionQueryRepository.findAllPositions()).thenReturn(mockResult);
 
-        // when
-        List<PositionResponse> result = positionQueryService.getPositions();
+    // when
+    List<PositionResponse> result = positionQueryService.getPositions();
 
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result).extracting("positionName")
-                .containsExactly("백엔드 개발자", "프론트엔드 개발자", "PM");
-    }
+    // then
+    assertThat(result).hasSize(3);
+    assertThat(result).extracting("positionName").containsExactly("백엔드 개발자", "프론트엔드 개발자", "PM");
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/member/query/service/PositionQueryServiceTest.java
+++ b/src/test/java/com/nexus/sion/feature/member/query/service/PositionQueryServiceTest.java
@@ -1,0 +1,50 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.PositionResponse;
+import com.nexus.sion.feature.member.query.repository.PositionQueryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+class PositionQueryServiceTest {
+
+    @Mock
+    private PositionQueryRepository positionQueryRepository;
+
+    @InjectMocks
+    private PositionQueryService positionQueryService;
+
+    @BeforeEach
+    void setUp() {
+        openMocks(this);
+    }
+
+    @Test
+    @DisplayName("직급 목록 조회 - 성공")
+    void getPositions_success() {
+        // given
+        List<PositionResponse> mockResult = List.of(
+                new PositionResponse("백엔드 개발자"),
+                new PositionResponse("프론트엔드 개발자"),
+                new PositionResponse("PM")
+        );
+
+        when(positionQueryRepository.findAllPositions()).thenReturn(mockResult);
+
+        // when
+        List<PositionResponse> result = positionQueryService.getPositions();
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting("positionName")
+                .containsExactly("백엔드 개발자", "프론트엔드 개발자", "PM");
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue
Closes #139 


<br>

## 🪐 작업 내용
- 직급 목록 조회 기능 구현
- 부서 목록 조회 기능 구현

<br>

## ✅ 체크리스트
- [x]  기능 구현
- [x]  service mock 단위 테스트
- [x]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
