### PR TITLE
[fix] base entity 설정으로 createdat, updatedat 코드 삭제

### DIFF
--- a/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
@@ -12,7 +12,6 @@ import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.project.command.domain.aggregate.Project;
 import com.nexus.sion.feature.project.command.domain.repository.ProjectRepository;
 import com.nexus.sion.feature.squad.command.application.dto.request.SquadRegisterRequest;
-import com.nexus.sion.feature.squad.command.application.dto.request.SquadRegisterRequest.Member;
 import com.nexus.sion.feature.squad.command.domain.aggregate.entity.Squad;
 import com.nexus.sion.feature.squad.command.domain.aggregate.entity.SquadEmployee;
 import com.nexus.sion.feature.squad.command.domain.aggregate.enums.OriginType;
@@ -62,8 +61,6 @@ public class SquadCommandServiceImpl implements SquadCommandService {
             .description(request.getDescription())
             .isActive(false)
             .originType(OriginType.MANUAL)
-            .createdAt(LocalDateTime.now())
-            .updatedAt(LocalDateTime.now())
             .build();
 
     squadCommandRepository.save(squad);
@@ -76,8 +73,6 @@ public class SquadCommandServiceImpl implements SquadCommandService {
                     .projectAndJobId(member.getProjectAndJobId())
                     .isLeader(false)
                     .assignedDate(LocalDate.now())
-                    .createdAt(LocalDateTime.now())
-                    .updatedAt(LocalDateTime.now())
                     .build())
             .toList();
 

--- a/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
@@ -66,7 +66,12 @@ class SquadCommandServiceImplTest {
     // then
     verify(projectRepository).findByProjectCode("ha_1_1");
     verify(squadCommandRepository).save(any(Squad.class));
-    verify(squadEmployeeCommandRepository).saveAll(anyList());
+ArgumentCaptor<List<SquadEmployee>> listCaptor = ArgumentCaptor.forClass(List.class);
+verify(squadEmployeeCommandRepository).saveAll(listCaptor.capture());
+
+List<SquadEmployee> capturedList = listCaptor.getValue();
+assertThat(capturedList).hasSize(1);
+assertThat(capturedList.get(0).getEmployeeIdentificationNumber()).isEqualTo("EMP001");
   }
 
   @Test

--- a/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
@@ -66,7 +66,7 @@ class SquadCommandServiceImplTest {
     // then
     verify(projectRepository).findByProjectCode("ha_1_1");
     verify(squadCommandRepository).save(any(Squad.class));
-    verify(squadEmployeeCommandRepository).save(any(SquadEmployee.class));
+    verify(squadEmployeeCommandRepository).saveAll(anyList());
   }
 
   @Test


### PR DESCRIPTION
## 🛰️ Issue
Closes #163 

<br>

## 🪐 작업 내용
BaseEntity의 자동 시간 설정 기능을 활용하여
ServiceImpl 내 createdAt, updatedAt 수동 설정 코드 제거

