### PR TITLE
[fix] 개발자 검색 로직 수정

### DIFF
--- a/src/main/java/com/nexus/sion/common/constants/CollationConstants.java
+++ b/src/main/java/com/nexus/sion/common/constants/CollationConstants.java
@@ -5,5 +5,5 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CollationConstants {
-    public static final String UTF8MB4_UNICODE_520_CI = "utf8mb4_unicode_520_ci";
+  public static final String UTF8MB4_UNICODE_520_CI = "utf8mb4_unicode_520_ci";
 }

--- a/src/main/java/com/nexus/sion/exception/ErrorCode.java
+++ b/src/main/java/com/nexus/sion/exception/ErrorCode.java
@@ -51,7 +51,8 @@ public enum ErrorCode {
   PROJECT_CODE_INVALID("40004", "유효하지 않은 프로젝트 코드입니다.", HttpStatus.BAD_REQUEST),
   COMMENT_NOT_FOUND("40005", "존재하지 않는 코멘트입니다.", HttpStatus.NOT_FOUND),
   INVALID_COMMENT_ACCESS("40006", "해당 스쿼드의 코멘트가 아닙니다.", HttpStatus.FORBIDDEN),
-  INVALID_SQUAD_PROJECT_CODE_FORMAT("40007", "프로젝트 코드 형식이 올바르지 않습니다. 예: ha_1_1", HttpStatus.BAD_REQUEST),
+  INVALID_SQUAD_PROJECT_CODE_FORMAT(
+      "40007", "프로젝트 코드 형식이 올바르지 않습니다. 예: ha_1_1", HttpStatus.BAD_REQUEST),
   SQUAD_ASSIGNMENT_FAILED("40008", "스쿼드 구성 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
   // techstack

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/request/MemberListRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/request/MemberListRequest.java
@@ -15,4 +15,6 @@ public class MemberListRequest {
   private String nameInitial;
   private String sortBy;
   private String sortDir;
+
+  private String keyword;
 }

--- a/src/main/java/com/nexus/sion/feature/project/query/controller/ProjectQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/controller/ProjectQueryController.java
@@ -1,8 +1,8 @@
 package com.nexus.sion.feature.project.query.controller;
 
-import com.nexus.sion.common.dto.ApiResponse;
 import org.springframework.web.bind.annotation.*;
 
+import com.nexus.sion.common.dto.ApiResponse;
 import com.nexus.sion.common.dto.PageResponse;
 import com.nexus.sion.feature.project.query.dto.request.ProjectListRequest;
 import com.nexus.sion.feature.project.query.dto.response.ProjectListResponse;
@@ -18,7 +18,8 @@ public class ProjectQueryController {
   private final ProjectQueryService projectQueryService;
 
   @PostMapping("/list")
-  public ApiResponse<PageResponse<ProjectListResponse>> searchProjects(@RequestBody ProjectListRequest request) {
+  public ApiResponse<PageResponse<ProjectListResponse>> searchProjects(
+      @RequestBody ProjectListRequest request) {
     PageResponse<ProjectListResponse> result = projectQueryService.findProjects(request);
     return ApiResponse.success(result);
   }

--- a/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package com.nexus.sion.feature.squad.command.application.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -66,14 +65,17 @@ public class SquadCommandServiceImpl implements SquadCommandService {
     squadCommandRepository.save(squad);
 
     // 6. 스쿼드 구성원 저장
-    List<SquadEmployee> squadEmployees = request.getMembers().stream()
-            .map(member -> SquadEmployee.builder()
-                    .squadCode(squad.getSquadCode())
-                    .employeeIdentificationNumber(member.getEmployeeIdentificationNumber())
-                    .projectAndJobId(member.getProjectAndJobId())
-                    .isLeader(false)
-                    .assignedDate(LocalDate.now())
-                    .build())
+    List<SquadEmployee> squadEmployees =
+        request.getMembers().stream()
+            .map(
+                member ->
+                    SquadEmployee.builder()
+                        .squadCode(squad.getSquadCode())
+                        .employeeIdentificationNumber(member.getEmployeeIdentificationNumber())
+                        .projectAndJobId(member.getProjectAndJobId())
+                        .isLeader(false)
+                        .assignedDate(LocalDate.now())
+                        .build())
             .toList();
 
     squadEmployeeCommandRepository.saveAll(squadEmployees);

--- a/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
+++ b/src/test/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImplTest.java
@@ -6,12 +6,12 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
-import com.nexus.sion.exception.BusinessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
+import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.project.command.domain.aggregate.Project;
 import com.nexus.sion.feature.project.command.domain.repository.ProjectRepository;
@@ -66,12 +66,12 @@ class SquadCommandServiceImplTest {
     // then
     verify(projectRepository).findByProjectCode("ha_1_1");
     verify(squadCommandRepository).save(any(Squad.class));
-ArgumentCaptor<List<SquadEmployee>> listCaptor = ArgumentCaptor.forClass(List.class);
-verify(squadEmployeeCommandRepository).saveAll(listCaptor.capture());
+    ArgumentCaptor<List<SquadEmployee>> listCaptor = ArgumentCaptor.forClass(List.class);
+    verify(squadEmployeeCommandRepository).saveAll(listCaptor.capture());
 
-List<SquadEmployee> capturedList = listCaptor.getValue();
-assertThat(capturedList).hasSize(1);
-assertThat(capturedList.get(0).getEmployeeIdentificationNumber()).isEqualTo("EMP001");
+    List<SquadEmployee> capturedList = listCaptor.getValue();
+    assertThat(capturedList).hasSize(1);
+    assertThat(capturedList.get(0).getEmployeeIdentificationNumber()).isEqualTo("EMP001");
   }
 
   @Test


### PR DESCRIPTION
## 🛰️ Issue
Closes #165 

<br>

## 🪐 작업 내용
- 개발자 검색시 AVAILABLE 상태인 개발자만 조회되는 버그 수정
- soft delete된 사용자도 조회되는 버그 수정
- 검색 API를 분리하지않고 목록 조회 API에 keyword 추가하는 식으로 수정

<br>

## ✅ 체크리스트
- [x]  기능 구현
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
