### PR TITLE
[feat] 등급별 대기 인원수 조회 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/statistics/query/controller/StatisticsQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/statistics/query/controller/StatisticsQueryController.java
@@ -82,4 +82,10 @@ public class StatisticsQueryController {
     var result = statisticsQueryService.getJobParticipationStats();
     return ResponseEntity.ok(ApiResponse.success(result));
   }
+
+  @GetMapping("/waiting-count-by-grade")
+  public ResponseEntity<ApiResponse<List<MemberWaitingCountDto>>> getWaitingCountsByGrade() {
+    List<MemberWaitingCountDto> result = statisticsQueryService.getWaitingCountsByGrade();
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/statistics/query/dto/MemberWaitingCountDto.java
+++ b/src/main/java/com/nexus/sion/feature/statistics/query/dto/MemberWaitingCountDto.java
@@ -1,0 +1,17 @@
+package com.nexus.sion.feature.statistics.query.dto;
+
+import com.example.jooq.generated.enums.MemberGradeCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberWaitingCountDto {
+  private MemberGradeCode gradeCode;
+  private int waitingCount;
+}

--- a/src/main/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryService.java
@@ -17,4 +17,6 @@ public interface StatisticsQueryService {
       String period, int page, int size, Integer top);
 
   List<JobParticipationStatsDto> getJobParticipationStats();
+
+  List<MemberWaitingCountDto> getWaitingCountsByGrade();
 }

--- a/src/main/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryServiceImpl.java
@@ -14,32 +14,38 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StatisticsQueryServiceImpl implements StatisticsQueryService {
 
-  private final StatisticsQueryRepository repository;
+  private final StatisticsQueryRepository statisticsQueryRepository;
 
   @Override
   public List<TechStackCountDto> getStackMemberCounts(List<String> stackNames) {
-    return repository.findStackMemberCount(stackNames);
+    return statisticsQueryRepository.findStackMemberCount(stackNames);
   }
 
   @Override
   public PageResponse<DeveloperDto> getAllDevelopers(int page, int size) {
-    return repository.findAllDevelopers(page, size);
+    return statisticsQueryRepository.findAllDevelopers(page, size);
   }
 
   @Override
   public PageResponse<TechStackCareerDto> getStackAverageCareersPaged(
       List<String> stackNames, int page, int size, String sort, String direction) {
-    return repository.findStackAverageCareerPaged(stackNames, page, size, sort, direction);
+    return statisticsQueryRepository.findStackAverageCareerPaged(
+        stackNames, page, size, sort, direction);
   }
 
   @Override
   public PageResponse<TechStackMonthlyUsageDto> getPopularTechStacksGroupedByMonth(
       String period, int page, int size, Integer top) {
-    return repository.findMonthlyPopularTechStacks(period, page, size, top);
+    return statisticsQueryRepository.findMonthlyPopularTechStacks(period, page, size, top);
   }
 
   @Override
   public List<JobParticipationStatsDto> getJobParticipationStats() {
-    return repository.getJobParticipationStats();
+    return statisticsQueryRepository.getJobParticipationStats();
+  }
+
+  @Override
+  public List<MemberWaitingCountDto> getWaitingCountsByGrade() {
+    return statisticsQueryRepository.findWaitingCountByGrade();
   }
 }

--- a/src/test/java/com/nexus/sion/feature/statistics/StatisticsQueryIntergrationTest.java
+++ b/src/test/java/com/nexus/sion/feature/statistics/StatisticsQueryIntergrationTest.java
@@ -122,4 +122,16 @@ class StatisticsQueryIntergrationTest {
         .andExpect(jsonPath("$.data[0].jobName").exists())
         .andExpect(jsonPath("$.data[0].memberCount").isNumber());
   }
+
+  @Test
+  @DisplayName("GET /grade/waiting - 등급별 대기 상태 인원 수 조회")
+  void getWaitingCountByGrade() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/statistics/waiting-count-by-grade"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data").isArray())
+        .andExpect(jsonPath("$.data[0].gradeCode").exists())
+        .andExpect(jsonPath("$.data[0].waitingCount").isNumber());
+  }
 }

--- a/src/test/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryServiceImplTest.java
+++ b/src/test/java/com/nexus/sion/feature/statistics/query/service/StatisticsQueryServiceImplTest.java
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.example.jooq.generated.enums.MemberGradeCode;
 import com.nexus.sion.common.dto.PageResponse;
 import com.nexus.sion.feature.statistics.query.dto.*;
 import com.nexus.sion.feature.statistics.query.repository.StatisticsQueryRepository;
@@ -106,6 +107,7 @@ class StatisticsQueryServiceImplTest {
     assertEquals(9, result.getContent().get(1).getMonthlyUsage().get("2025-02"));
   }
 
+  // 직무별 등록된 인원수
   @Test
   void getJobParticipationStats_returnsStatsList() {
     List<JobParticipationStatsDto> mockResult =
@@ -131,5 +133,24 @@ class StatisticsQueryServiceImplTest {
     assertEquals("백엔드", result.get(0).getJobName());
     assertEquals(8, result.get(1).getMemberCount());
     assertEquals("Vue", result.get(1).getTopTechStack1());
+  }
+
+  // 등급별 대기 상태 인원 수 조회 기능을 테스트
+  @Test
+  void getWaitingCountByGrade_returnsWaitingStats() {
+    List<MemberWaitingCountDto> mockResult =
+        List.of(
+            new MemberWaitingCountDto(MemberGradeCode.S, 3),
+            new MemberWaitingCountDto(MemberGradeCode.A, 2),
+            new MemberWaitingCountDto(MemberGradeCode.B, 0));
+
+    when(repository.findWaitingCountByGrade()).thenReturn(mockResult);
+
+    List<MemberWaitingCountDto> result = service.getWaitingCountsByGrade();
+
+    assertEquals(3, result.size());
+    assertEquals(MemberGradeCode.S, result.get(0).getGradeCode());
+    assertEquals(2, result.get(1).getWaitingCount());
+    assertEquals(0, result.get(2).getWaitingCount());
   }
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #50 


<br>

## 🪐 작업 내용
등급별로 상태가 '대기중' 인 사람들의 수를 조회하는 기능입니다.


<br>

## 📚 논의하고 싶은 내용 (선택)


<br>

## ✅ 체크리스트
- [x]  기능 구현
- [x]  service mock 단위 테스트
- [x]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
