### PR TITLE
[feat] 프로젝트 상태 및 확정 여부에 따른 스쿼드 조회 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
@@ -17,8 +17,8 @@ public class SquadQueryController {
   private final SquadQueryService squadQueryService;
 
   @GetMapping("/project/{projectCode}")
-  public ResponseEntity<?> getSquadsOrConfirmed(
-      @PathVariable String projectCode, @ModelAttribute SquadListRequest request) {
+  public ResponseEntity<Object> getSquadsOrConfirmed(
+          @PathVariable String projectCode, @ModelAttribute SquadListRequest request) {
     request.setProjectCode(projectCode);
     Object response = squadQueryService.findSquadsOrConfirmed(request);
     return ResponseEntity.ok(response);

--- a/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.feature.squad.query.dto.request.SquadListRequest;
 import com.nexus.sion.feature.squad.query.dto.response.SquadDetailResponse;
-import com.nexus.sion.feature.squad.query.dto.response.SquadListResultResponse;
 import com.nexus.sion.feature.squad.query.service.SquadQueryService;
 
 import lombok.RequiredArgsConstructor;
@@ -19,14 +18,11 @@ public class SquadQueryController {
 
   @GetMapping("/project/{projectCode}")
   public ResponseEntity<?> getSquadsOrConfirmed(
-          @PathVariable String projectCode,
-          @ModelAttribute SquadListRequest request
-  ) {
+      @PathVariable String projectCode, @ModelAttribute SquadListRequest request) {
     request.setProjectCode(projectCode);
     Object response = squadQueryService.findSquadsOrConfirmed(request);
     return ResponseEntity.ok(response);
   }
-
 
   @GetMapping("/{squadCode}")
   public ResponseEntity<SquadDetailResponse> getSquadDetail(@PathVariable String squadCode) {

--- a/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/controller/SquadQueryController.java
@@ -18,11 +18,15 @@ public class SquadQueryController {
   private final SquadQueryService squadQueryService;
 
   @GetMapping("/project/{projectCode}")
-  public ResponseEntity<SquadListResultResponse> getSquads(
-      @PathVariable String projectCode, @ModelAttribute SquadListRequest request) {
+  public ResponseEntity<?> getSquadsOrConfirmed(
+          @PathVariable String projectCode,
+          @ModelAttribute SquadListRequest request
+  ) {
     request.setProjectCode(projectCode);
-    return ResponseEntity.ok(squadQueryService.findSquads(request));
+    Object response = squadQueryService.findSquadsOrConfirmed(request);
+    return ResponseEntity.ok(response);
   }
+
 
   @GetMapping("/{squadCode}")
   public ResponseEntity<SquadDetailResponse> getSquadDetail(@PathVariable String squadCode) {

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -258,28 +258,26 @@ public class SquadQueryRepository {
         comments);
   }
 
-    public boolean existsByProjectCodeAndIsActive(String projectCode) {
-        return dsl.fetchExists(
-                dsl.selectFrom(SQUAD)
-                        .where(SQUAD.PROJECT_CODE.eq(projectCode))
-                        .and(SQUAD.IS_ACTIVE.isTrue())
-        );
+  public boolean existsByProjectCodeAndIsActive(String projectCode) {
+    return dsl.fetchExists(
+        dsl.selectFrom(SQUAD)
+            .where(SQUAD.PROJECT_CODE.eq(projectCode))
+            .and(SQUAD.IS_ACTIVE.isTrue()));
+  }
+
+  public Optional<SquadDetailResponse> findConfirmedSquadByProjectCode(String projectCode) {
+    String squadCode =
+        dsl.select(SQUAD.SQUAD_CODE)
+            .from(SQUAD)
+            .where(SQUAD.PROJECT_CODE.eq(projectCode))
+            .and(SQUAD.IS_ACTIVE.isTrue())
+            .fetchOneInto(String.class);
+
+    if (squadCode == null) {
+      return Optional.empty();
     }
 
-    public Optional<SquadDetailResponse> findConfirmedSquadByProjectCode(String projectCode) {
-        String squadCode = dsl
-                .select(SQUAD.SQUAD_CODE)
-                .from(SQUAD)
-                .where(SQUAD.PROJECT_CODE.eq(projectCode))
-                .and(SQUAD.IS_ACTIVE.isTrue())
-                .fetchOneInto(String.class);
-
-        if (squadCode == null) {
-            return Optional.empty();
-        }
-
-        // 기존 상세 조회 재사용
-        return Optional.of(findSquadDetailByCode(squadCode));
-    }
-
+    // 기존 상세 조회 재사용
+    return Optional.of(findSquadDetailByCode(squadCode));
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -11,6 +11,7 @@ import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jooq.*;
@@ -256,4 +257,29 @@ public class SquadQueryRepository {
         squadRecord.get(SQUAD.RECOMMENDATION_REASON),
         comments);
   }
+
+    public boolean existsByProjectCodeAndIsActive(String projectCode) {
+        return dsl.fetchExists(
+                dsl.selectFrom(SQUAD)
+                        .where(SQUAD.PROJECT_CODE.eq(projectCode))
+                        .and(SQUAD.IS_ACTIVE.isTrue())
+        );
+    }
+
+    public Optional<SquadDetailResponse> findConfirmedSquadByProjectCode(String projectCode) {
+        String squadCode = dsl
+                .select(SQUAD.SQUAD_CODE)
+                .from(SQUAD)
+                .where(SQUAD.PROJECT_CODE.eq(projectCode))
+                .and(SQUAD.IS_ACTIVE.isTrue())
+                .fetchOneInto(String.class);
+
+        if (squadCode == null) {
+            return Optional.empty();
+        }
+
+        // 기존 상세 조회 재사용
+        return Optional.of(findSquadDetailByCode(squadCode));
+    }
+
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -265,19 +265,18 @@ public class SquadQueryRepository {
             .and(SQUAD.IS_ACTIVE.isTrue()));
   }
 
-  public Optional<SquadDetailResponse> findConfirmedSquadByProjectCode(String projectCode) {
-    String squadCode =
+    public SquadDetailResponse findConfirmedSquadByProjectCode(String projectCode) {
+        String squadCode =
         dsl.select(SQUAD.SQUAD_CODE)
             .from(SQUAD)
             .where(SQUAD.PROJECT_CODE.eq(projectCode))
             .and(SQUAD.IS_ACTIVE.isTrue())
             .fetchOneInto(String.class);
 
-    if (squadCode == null) {
-      return Optional.empty();
-    }
+      if (squadCode == null) {
+          throw new BusinessException(ErrorCode.SQUAD_DETAIL_NOT_FOUND);
+      }
 
-    // 기존 상세 조회 재사용
-    return Optional.of(findSquadDetailByCode(squadCode));
+      return findSquadDetailByCode(squadCode);
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryService.java
@@ -11,4 +11,13 @@ public interface SquadQueryService {
 
   // 스쿼드 상세 조회
   SquadDetailResponse getSquadDetailByCode(String squadCode);
+
+  // 확정된 스쿼드가 있으면 상세, 없으면 목록 조회
+  Object findSquadsOrConfirmed(SquadListRequest request);
+
+  // 해당 프로젝트에 확정된 스쿼드가 있는지 확인
+  boolean hasConfirmedSquad(String projectCode);
+
+  // 해당 프로젝트의 확정된 스쿼드 상세 조회
+  SquadDetailResponse getConfirmedSquadByProjectCode(String projectCode);
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.nexus.sion.feature.squad.query.service;
 
+import com.nexus.sion.feature.project.command.domain.aggregate.Project;
+import com.nexus.sion.feature.project.command.domain.repository.ProjectRepository;
 import org.springframework.stereotype.Service;
 
 import com.nexus.sion.exception.BusinessException;
@@ -11,21 +13,20 @@ import com.nexus.sion.feature.squad.query.repository.SquadQueryRepository;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SquadQueryServiceImpl implements SquadQueryService {
 
   private final SquadQueryRepository squadQueryRepository;
+  private final ProjectRepository projectRepository;
+
 
   @Override
   public SquadListResultResponse findSquads(SquadListRequest request) {
     SquadListResultResponse result = squadQueryRepository.findSquads(request);
-
-    if (result == null || result.getContent().isEmpty()) {
-      throw new BusinessException(ErrorCode.PROJECT_SQUAD_NOT_FOUND);
-    }
-
-    return result;
+    return result != null ? result : new SquadListResultResponse(List.of(), request.getPage(), request.getSize(), 0L);
   }
 
   @Override
@@ -37,5 +38,39 @@ public class SquadQueryServiceImpl implements SquadQueryService {
     }
 
     return response;
+  }
+
+  public Object findSquadsOrConfirmed(SquadListRequest request) {
+    String projectCode = request.getProjectCode();
+
+    Project project = projectRepository.findById(projectCode)
+            .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+
+    // ✅ 종료된 프로젝트면 무조건 확정된 스쿼드만 보여주기
+    if (project.getStatus() == Project.ProjectStatus.COMPLETE
+            || project.getStatus() == Project.ProjectStatus.INCOMPLETE) {
+
+      SquadDetailResponse confirmed = getConfirmedSquadByProjectCode(projectCode);
+      return confirmed;
+    }
+
+    // ✅ 진행 중 프로젝트인 경우
+    if (hasConfirmedSquad(projectCode)) {
+      return getConfirmedSquadByProjectCode(projectCode);
+    }
+
+    return findSquads(request);
+  }
+
+
+  @Override
+  public boolean hasConfirmedSquad(String projectCode) {
+    return squadQueryRepository.existsByProjectCodeAndIsActive(projectCode);
+  }
+
+  @Override
+  public SquadDetailResponse getConfirmedSquadByProjectCode(String projectCode) {
+    return squadQueryRepository.findConfirmedSquadByProjectCode(projectCode)
+            .orElseThrow(() -> new BusinessException(ErrorCode.SQUAD_DETAIL_NOT_FOUND));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
@@ -53,7 +53,15 @@ public class SquadQueryServiceImpl implements SquadQueryService {
     if (project.getStatus() == Project.ProjectStatus.COMPLETE
         || project.getStatus() == Project.ProjectStatus.INCOMPLETE) {
 
-      SquadDetailResponse confirmed = getConfirmedSquadByProjectCode(projectCode);
+      // 예외 발생 대신 null 체크 후 fallback 처리
+      SquadDetailResponse confirmed = null;
+      try {
+        confirmed = getConfirmedSquadByProjectCode(projectCode);
+      } catch (BusinessException e) {
+        // 로그를 남기고 빈 응답 반환
+        return null; // 또는 Optional.empty() 또는 new SquadDetailResponse() 등
+      }
+
       return confirmed;
     }
 
@@ -72,8 +80,6 @@ public class SquadQueryServiceImpl implements SquadQueryService {
 
   @Override
   public SquadDetailResponse getConfirmedSquadByProjectCode(String projectCode) {
-    return squadQueryRepository
-        .findConfirmedSquadByProjectCode(projectCode)
-        .orElseThrow(() -> new BusinessException(ErrorCode.SQUAD_DETAIL_NOT_FOUND));
+    return squadQueryRepository.findConfirmedSquadByProjectCode(projectCode);
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/service/SquadQueryServiceImpl.java
@@ -1,19 +1,19 @@
 package com.nexus.sion.feature.squad.query.service;
 
-import com.nexus.sion.feature.project.command.domain.aggregate.Project;
-import com.nexus.sion.feature.project.command.domain.repository.ProjectRepository;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
+import com.nexus.sion.feature.project.command.domain.aggregate.Project;
+import com.nexus.sion.feature.project.command.domain.repository.ProjectRepository;
 import com.nexus.sion.feature.squad.query.dto.request.SquadListRequest;
 import com.nexus.sion.feature.squad.query.dto.response.SquadDetailResponse;
 import com.nexus.sion.feature.squad.query.dto.response.SquadListResultResponse;
 import com.nexus.sion.feature.squad.query.repository.SquadQueryRepository;
 
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,11 +22,12 @@ public class SquadQueryServiceImpl implements SquadQueryService {
   private final SquadQueryRepository squadQueryRepository;
   private final ProjectRepository projectRepository;
 
-
   @Override
   public SquadListResultResponse findSquads(SquadListRequest request) {
     SquadListResultResponse result = squadQueryRepository.findSquads(request);
-    return result != null ? result : new SquadListResultResponse(List.of(), request.getPage(), request.getSize(), 0L);
+    return result != null
+        ? result
+        : new SquadListResultResponse(List.of(), request.getPage(), request.getSize(), 0L);
   }
 
   @Override
@@ -43,12 +44,14 @@ public class SquadQueryServiceImpl implements SquadQueryService {
   public Object findSquadsOrConfirmed(SquadListRequest request) {
     String projectCode = request.getProjectCode();
 
-    Project project = projectRepository.findById(projectCode)
+    Project project =
+        projectRepository
+            .findById(projectCode)
             .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
     // ✅ 종료된 프로젝트면 무조건 확정된 스쿼드만 보여주기
     if (project.getStatus() == Project.ProjectStatus.COMPLETE
-            || project.getStatus() == Project.ProjectStatus.INCOMPLETE) {
+        || project.getStatus() == Project.ProjectStatus.INCOMPLETE) {
 
       SquadDetailResponse confirmed = getConfirmedSquadByProjectCode(projectCode);
       return confirmed;
@@ -62,7 +65,6 @@ public class SquadQueryServiceImpl implements SquadQueryService {
     return findSquads(request);
   }
 
-
   @Override
   public boolean hasConfirmedSquad(String projectCode) {
     return squadQueryRepository.existsByProjectCodeAndIsActive(projectCode);
@@ -70,7 +72,8 @@ public class SquadQueryServiceImpl implements SquadQueryService {
 
   @Override
   public SquadDetailResponse getConfirmedSquadByProjectCode(String projectCode) {
-    return squadQueryRepository.findConfirmedSquadByProjectCode(projectCode)
-            .orElseThrow(() -> new BusinessException(ErrorCode.SQUAD_DETAIL_NOT_FOUND));
+    return squadQueryRepository
+        .findConfirmedSquadByProjectCode(projectCode)
+        .orElseThrow(() -> new BusinessException(ErrorCode.SQUAD_DETAIL_NOT_FOUND));
   }
 }


### PR DESCRIPTION
## 🛰️ Issue
Close #191 


<br>

## 🪐 작업 내용
`/api/v1/squads/project/{projectCode}` 엔드포인트에 프로젝트 상태 기반 분기 로직 구현
종료된 프로젝트(`COMPLETE`, `INCOMPLETE`)는 `is_active = true`인 확정 스쿼드만 상세 조회
진행 중인 프로젝트(`WAITING`, `IN_PROGRESS`)는 확정 여부에 따라 목록 또는 상세 조회
`SquadQueryRepository`에 확정 스쿼드 존재 여부 및 상세 조회 쿼리 추가


<br>

## ✅ 체크리스트
- [x]  기능 구현
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
