### PR TITLE
[feat] 관리자 자격증 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/CertificateCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/CertificateCommandController.java
@@ -1,6 +1,5 @@
 package com.nexus.sion.feature.member.command.application.controller;
 
-import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.common.dto.ApiResponse;
 import com.nexus.sion.feature.member.command.application.dto.request.CertificateCreateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 import com.nexus.sion.feature.member.command.application.service.CertificateCommandService;
 
 import lombok.RequiredArgsConstructor;
@@ -31,18 +31,14 @@ public class CertificateCommandController {
   /* 관리자의 자격증 종류 수정 */
   @PatchMapping("/{certificateName}")
   public ResponseEntity<ApiResponse<Void>> updateCertificate(
-          @PathVariable String certificateName,
-          @Valid @RequestBody CertificateUpdateRequest request
-  ) {
+      @PathVariable String certificateName, @Valid @RequestBody CertificateUpdateRequest request) {
     certificateService.updateCertificate(certificateName, request);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 
   /* 관리자의 자격증 종류 삭제 */
   @DeleteMapping("/{certificateName}")
-  public ResponseEntity<ApiResponse<Void>> deleteCertificate(
-          @PathVariable String certificateName
-  ) {
+  public ResponseEntity<ApiResponse<Void>> deleteCertificate(@PathVariable String certificateName) {
     certificateService.deleteCertificate(certificateName);
     return ResponseEntity.ok(ApiResponse.success(null));
   }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/CertificateCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/CertificateCommandController.java
@@ -1,5 +1,6 @@
 package com.nexus.sion.feature.member.command.application.controller;
 
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -7,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.command.application.dto.request.CertificateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateCreateRequest;
 import com.nexus.sion.feature.member.command.application.service.CertificateCommandService;
 
 import lombok.RequiredArgsConstructor;
@@ -22,8 +23,27 @@ public class CertificateCommandController {
   /* 관리자의 자격증 종류 등록 */
   @PostMapping("/register")
   public ResponseEntity<ApiResponse<Void>> registerCertificate(
-      @RequestBody @Valid CertificateRequest request) {
+      @RequestBody @Valid CertificateCreateRequest request) {
     certificateService.registerCertificate(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+  }
+
+  /* 관리자의 자격증 종류 수정 */
+  @PatchMapping("/{certificateName}")
+  public ResponseEntity<ApiResponse<Void>> updateCertificate(
+          @PathVariable String certificateName,
+          @Valid @RequestBody CertificateUpdateRequest request
+  ) {
+    certificateService.updateCertificate(certificateName, request);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  /* 관리자의 자격증 종류 삭제 */
+  @DeleteMapping("/{certificateName}")
+  public ResponseEntity<ApiResponse<Void>> deleteCertificate(
+          @PathVariable String certificateName
+  ) {
+    certificateService.deleteCertificate(certificateName);
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateCreateRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateCreateRequest.java
@@ -8,7 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class CertificateRequest {
+public class CertificateCreateRequest {
 
   @NotBlank(message = "자격증명은 필수입니다.")
   private String certificateName;

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateUpdateRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.nexus.sion.feature.member.command.application.dto.request;
+
+import jakarta.validation.constraints.*;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CertificateUpdateRequest {
+
+  @NotBlank(message = "발급기관은 필수입니다.")
+  private String issuingOrganization;
+
+  @NotNull(message = "점수는 필수 항목입니다.")
+  private Integer score;
+}

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandService.java
@@ -1,7 +1,12 @@
 package com.nexus.sion.feature.member.command.application.service;
 
-import com.nexus.sion.feature.member.command.application.dto.request.CertificateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateCreateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 
 public interface CertificateCommandService {
-  void registerCertificate(CertificateRequest request);
+  void registerCertificate(CertificateCreateRequest request);
+
+  void updateCertificate(String certificateName, CertificateUpdateRequest request);
+
+  void deleteCertificate(String certificateName);
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandServiceImpl.java
@@ -2,13 +2,17 @@ package com.nexus.sion.feature.member.command.application.service;
 
 import java.time.LocalDateTime;
 
+import com.nexus.sion.exception.BusinessException;
+import com.nexus.sion.exception.ErrorCode;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 import org.springframework.stereotype.Service;
 
-import com.nexus.sion.feature.member.command.application.dto.request.CertificateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateCreateRequest;
 import com.nexus.sion.feature.member.command.domain.aggregate.entity.Certificate;
 import com.nexus.sion.feature.member.command.domain.repository.CertificateRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +21,7 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
   private final CertificateRepository certificateRepository;
 
   @Override
-  public void registerCertificate(CertificateRequest request) {
+  public void registerCertificate(CertificateCreateRequest request) {
     Certificate certificate =
         Certificate.builder()
             .certificateName(request.getCertificateName())
@@ -28,5 +32,23 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
             .build();
 
     certificateRepository.save(certificate);
+  }
+
+  @Transactional
+  @Override
+  public void updateCertificate(String certificateName, CertificateUpdateRequest request) {
+    Certificate certificate = certificateRepository.findById(certificateName)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
+
+    certificate.update(request.getScore(), request.getIssuingOrganization());
+  }
+
+  @Transactional
+  @Override
+  public void deleteCertificate(String certificateName) {
+    Certificate certificate = certificateRepository.findById(certificateName)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
+
+    certificateRepository.delete(certificate);
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/CertificateCommandServiceImpl.java
@@ -2,17 +2,17 @@ package com.nexus.sion.feature.member.command.application.service;
 
 import java.time.LocalDateTime;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
-import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
-import org.springframework.stereotype.Service;
-
 import com.nexus.sion.feature.member.command.application.dto.request.CertificateCreateRequest;
+import com.nexus.sion.feature.member.command.application.dto.request.CertificateUpdateRequest;
 import com.nexus.sion.feature.member.command.domain.aggregate.entity.Certificate;
 import com.nexus.sion.feature.member.command.domain.repository.CertificateRepository;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +37,9 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
   @Transactional
   @Override
   public void updateCertificate(String certificateName, CertificateUpdateRequest request) {
-    Certificate certificate = certificateRepository.findById(certificateName)
+    Certificate certificate =
+        certificateRepository
+            .findById(certificateName)
             .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
 
     certificate.update(request.getScore(), request.getIssuingOrganization());
@@ -46,7 +48,9 @@ public class CertificateCommandServiceImpl implements CertificateCommandService 
   @Transactional
   @Override
   public void deleteCertificate(String certificateName) {
-    Certificate certificate = certificateRepository.findById(certificateName)
+    Certificate certificate =
+        certificateRepository
+            .findById(certificateName)
             .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
 
     certificateRepository.delete(certificate);

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Certificate.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Certificate.java
@@ -29,4 +29,12 @@ public class Certificate {
 
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt = LocalDateTime.now();
+
+  public void update(int score, String issuingOrganization) {
+    this.score = score;
+    this.issuingOrganization = issuingOrganization;
+    this.updatedAt = LocalDateTime.now();
+  }
 }
+
+

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Certificate.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/Certificate.java
@@ -36,5 +36,3 @@ public class Certificate {
     this.updatedAt = LocalDateTime.now();
   }
 }
-
-

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/repository/CertificateRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/repository/CertificateRepository.java
@@ -1,17 +1,17 @@
 package com.nexus.sion.feature.member.command.domain.repository;
 
-import com.nexus.sion.feature.member.query.dto.response.CertificateResponse;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Certificate;
-import org.springframework.data.jpa.repository.Query;
-
 import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Certificate;
+import com.nexus.sion.feature.member.query.dto.response.CertificateResponse;
 
 public interface CertificateRepository extends JpaRepository<Certificate, String> {
 
-    @Query("SELECT new com.nexus.sion.feature.member.query.dto.response.CertificateResponse(" +
-            "c.certificateName, c.score, c.issuingOrganization) FROM Certificate c")
-    List<CertificateResponse> findAllAsResponse();
+  @Query(
+      "SELECT new com.nexus.sion.feature.member.query.dto.response.CertificateResponse("
+          + "c.certificateName, c.score, c.issuingOrganization) FROM Certificate c")
+  List<CertificateResponse> findAllAsResponse();
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #250 
Closes #251


<br>

## 🪐 작업 내용
자격증 수정 기능 구현
관리자용 자격증 수정 API (PATCH /api/v1/certificates/{certificateName}) 추가
CertificateUpdateRequest DTO 생성 (점수, 발급기관 수정)
Certificate 엔티티에 update(score, issuingOrganization) 메서드 추가
CertificateCommandService 및 CertificateCommandController에 수정 기능 구현

자격증 삭제 기능 구현
관리자용 자격증 삭제 API (DELETE /api/v1/certificates/{certificateName}) 추가
외래키 제약 조건을 ON DELETE CASCADE로 수정하여 관련 사용자 자격증 이력 자동 삭제
삭제 시 존재 여부 예외 처리 (CERTIFICATE_NOT_FOUND)

<br>

## ✅ 체크리스트
- [x]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
