### PR TITLE
[feat] 개발자의 프로젝트 이력 등록 요청 시 모든 관리자에게 알림이 가도록 서비스를 연결

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.nexus.sion.feature.member.command.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.ibatis.annotations.Param;
@@ -26,4 +27,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
       @Param("employeeIdentificationNumber") String employeeIdentificationNumber);
 
   boolean existsByEmployeeIdentificationNumberAndRole(String adminId, MemberRole memberRole);
+
+    List<Member> findAllByRole(MemberRole memberRole);
 }

--- a/src/main/java/com/nexus/sion/feature/notification/command/domain/aggregate/NotificationType.java
+++ b/src/main/java/com/nexus/sion/feature/notification/command/domain/aggregate/NotificationType.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 public enum NotificationType {
 
   /** 업무 업로드 요청 알림 */
-  TASK_UPLOAD_REQUEST("프로젝트가 종료되었습니다. 진행하신 업무 결과물을 업로드해주세요."),
+  TASK_UPLOAD_REQUEST("프로젝트가 종료되었습니다. 진행하신 프로젝트의 이력을 등록해주세요."),
 
   /** FP 분석 완료 알림 */
   FP_ANALYSIS_COMPLETE("FP 분석이 완료되었습니다. 결과를 확인해주세요."),
@@ -27,7 +27,7 @@ public enum NotificationType {
   GRADE_CHANGE("등급이 변경되었습니다."),
 
   /** 프로젝트 업무 승인 요청 알림 */
-  TASK_APPROVAL_REQUEST("{username}님의 프로젝트 업무 업로드가 완료되었습니다."),
+  TASK_APPROVAL_REQUEST("{username}님의 프로젝트 이력 등록 요청이 들어왔습니다."),
 
   /** 자격증 등록 승인 요청 알림 */
   CERTIFICATION_APPROVAL_REQUEST("{username}님의 자격증 등록 요청이 들어왔습니다.");

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkServiceImpl.java
@@ -2,6 +2,9 @@ package com.nexus.sion.feature.project.command.application.service;
 
 import java.util.List;
 
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
+import com.nexus.sion.feature.notification.command.application.service.NotificationCommandService;
+import com.nexus.sion.feature.notification.command.domain.aggregate.NotificationType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,7 @@ public class DeveloperProjectWorkServiceImpl implements DeveloperProjectWorkServ
   private final DeveloperProjectWorkRepository workRepository;
   private final DeveloperProjectWorkHistoryRepository workHistoryRepository;
   private final DeveloperProjectWorkHistoryTechStackRepository workHistoryTechStackRepository;
+  private final NotificationCommandService notificationCommandService;
 
   private final MemberRepository memberRepository;
 
@@ -63,37 +67,50 @@ public class DeveloperProjectWorkServiceImpl implements DeveloperProjectWorkServ
   @Transactional
   public void addHistories(Long workId, WorkHistoryAddRequestDto dto) {
     DeveloperProjectWork work =
-        workRepository
-            .findById(workId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.WORK_NOT_FOUND));
+            workRepository
+                    .findById(workId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.WORK_NOT_FOUND));
 
     work.setApprovalStatus(DeveloperProjectWork.ApprovalStatus.PENDING);
 
     for (WorkHistoryAddRequestDto.WorkHistoryItemDto item : dto.getHistories()) {
       DeveloperProjectWorkHistory history =
-          DeveloperProjectWorkHistory.builder()
-              .developerProjectWorkId(workId)
-              .functionName(item.getFunctionName())
-              .functionDescription(item.getFunctionDescription())
-              .functionType(
-                  DeveloperProjectWorkHistory.FunctionType.valueOf(item.getFunctionType()))
-              .det(Integer.parseInt(item.getDet()))
-              .ftr(Integer.parseInt(item.getFtr()))
-              .build();
+              DeveloperProjectWorkHistory.builder()
+                      .developerProjectWorkId(workId)
+                      .functionName(item.getFunctionName())
+                      .functionDescription(item.getFunctionDescription())
+                      .functionType(DeveloperProjectWorkHistory.FunctionType.valueOf(item.getFunctionType()))
+                      .det(Integer.parseInt(item.getDet()))
+                      .ftr(Integer.parseInt(item.getFtr()))
+                      .build();
 
       workHistoryRepository.save(history);
 
       List<DeveloperProjectWorkHistoryTechStack> techStacks =
-          item.getTechStackNames().stream()
-              .map(
-                  name ->
-                      DeveloperProjectWorkHistoryTechStack.builder()
-                          .developerProjectWorkHistoryId(history.getId())
-                          .techStackName(name)
-                          .build())
-              .toList();
+              item.getTechStackNames().stream()
+                      .map(name ->
+                              DeveloperProjectWorkHistoryTechStack.builder()
+                                      .developerProjectWorkHistoryId(history.getId())
+                                      .techStackName(name)
+                                      .build())
+                      .toList();
 
       workHistoryTechStackRepository.saveAll(techStacks);
+    }
+
+    // ===== 알림 전송 로직 추가 =====
+    String senderId = work.getEmployeeIdentificationNumber(); // 요청 보낸 개발자
+
+    // 관리자 목록 조회
+    List<Member> adminMembers = memberRepository.findAllByRole(MemberRole.ADMIN);
+    for (Member admin : adminMembers) {
+      notificationCommandService.createAndSendNotification(
+              senderId,
+              admin.getEmployeeIdentificationNumber(),
+              null, // message는 null로 두면 NotificationType이 자동 메시지 생성
+              NotificationType.TASK_APPROVAL_REQUEST,
+              String.valueOf(workId) // linkedContentId는 작업 ID 사용
+      );
     }
   }
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #282


<br>

## 🪐 작업 내용
개발자의 프로젝트 이력 등록 요청 시 모든 관리자에게 알림이 가도록 서비스를 연결


<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [x]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [ ]  spotless apply 적용 여부
      `./gradlew spotlessApply`
