### PR TITLE
[Feat] 프리랜서 이력서 기반 점수 산정 로직 구현

### DIFF
--- a/src/main/java/com/nexus/sion/exception/ErrorCode.java
+++ b/src/main/java/com/nexus/sion/exception/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
   // FP
   FP_NOT_FOUND("70001", "총 FP 포인트가 없는 프로젝트 평가입니다.", HttpStatus.NOT_FOUND),
   PROJECT_ANALYSIS_ALREADY_IN_PROGRESS("70002", "이미 분석이 진행 중이거나 완료된 프로젝트입니다.", HttpStatus.CONFLICT),
+  FP_ANALYZE_FAIL("70003","FP 분석에 실패했습니다.", HttpStatus.CONFLICT ),
 
   // developer project work
   WORK_HISTORY_NOT_FOUND("80001", "작업 이력이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
@@ -94,8 +95,7 @@ public enum ErrorCode {
   WORK_NOT_FOUND("80003", "해당 개발자 프로젝트 작업이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
   // notification
-  NOTIFICATION_NOT_FOUND("90001", "해당 알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-  ;
+  NOTIFICATION_NOT_FOUND("90001", "해당 알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
   private final String code;
   private final String message;
   private final HttpStatus httpStatus;

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
@@ -1,26 +1,24 @@
 package com.nexus.sion.feature.member.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.command.application.service.FreelancerCommandService;
+import com.nexus.sion.feature.member.command.application.service.FreelancerCommandServiceImpl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/freelancers")
 public class FreelancerCommandController {
 
-  private final FreelancerCommandService freelancerCommandService;
+  private final FreelancerCommandServiceImpl freelancerCommandService;
 
   @PostMapping("/{freelancerId}/register")
-  public ResponseEntity<ApiResponse<Void>> registerAsMember(@PathVariable String freelancerId) {
-    freelancerCommandService.registerFreelancerAsMember(freelancerId);
+  public ResponseEntity<ApiResponse<Void>> registerAsMember(@PathVariable String freelancerId, @RequestParam("file") MultipartFile multipartFile) {
+    freelancerCommandService.registerFreelancerAsMember(freelancerId, multipartFile);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/response/FreelencerFpInferResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/response/FreelencerFpInferResponse.java
@@ -1,0 +1,13 @@
+package com.nexus.sion.feature.member.command.application.dto.response;
+
+import com.nexus.sion.feature.project.command.application.dto.FunctionScore;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString
+public class FreelencerFpInferResponse {
+    private List<FunctionScore> functions;
+}

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
@@ -1,60 +1,7 @@
 package com.nexus.sion.feature.member.command.application.service;
 
-import java.time.LocalDate;
+import org.springframework.web.multipart.MultipartFile;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
-import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberRole;
-import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberStatus;
-import com.nexus.sion.feature.member.command.domain.repository.FreelancerRepository;
-import com.nexus.sion.feature.member.command.domain.repository.MemberRepository;
-import com.nexus.sion.feature.member.query.dto.response.FreelancerDetailResponse;
-import com.nexus.sion.feature.member.query.repository.FreelancerQueryRepository;
-
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class FreelancerCommandService {
-
-  private final FreelancerQueryRepository freelancerQueryRepository;
-  private final MemberRepository memberRepository;
-  private final FreelancerRepository freelancerRepository;
-  private final PasswordEncoder passwordEncoder;
-
-  public void registerFreelancerAsMember(String freelancerId) {
-    FreelancerDetailResponse freelancer =
-        freelancerQueryRepository.getFreelancerDetail(freelancerId);
-
-    String rawPassword =
-        (freelancer.birthday() != null)
-            ? String.format(
-                "%02d%02d%02d",
-                freelancer.birthday().getYear() % 100,
-                freelancer.birthday().getMonthValue(),
-                freelancer.birthday().getDayOfMonth())
-            : "000000";
-
-    String encodedPassword = passwordEncoder.encode(rawPassword);
-
-    Member member =
-        Member.builder()
-            .employeeIdentificationNumber(freelancer.freelancerId())
-            .employeeName(freelancer.name())
-            .password(encodedPassword)
-            .profileImageUrl(freelancer.profileImageUrl())
-            .phoneNumber(freelancer.phoneNumber())
-            .email(freelancer.email())
-            .birthday(freelancer.birthday())
-            .careerYears(freelancer.careerYears())
-            .joinedAt(LocalDate.now())
-            .role(MemberRole.OUTSIDER)
-            .status(MemberStatus.AVAILABLE)
-            .build();
-
-    memberRepository.save(member);
-    freelancerRepository.deleteById(freelancer.freelancerId());
-  }
+public interface FreelancerCommandService {
+    void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile);
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
@@ -1,0 +1,166 @@
+package com.nexus.sion.feature.member.command.application.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.nexus.sion.common.fastapi.FastApiClient;
+import com.nexus.sion.exception.BusinessException;
+import com.nexus.sion.exception.ErrorCode;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.DeveloperTechStack;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.DeveloperTechStackHistory;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.MemberScoreHistory;
+import com.nexus.sion.feature.member.command.domain.repository.*;
+import com.nexus.sion.feature.project.command.application.dto.FunctionScore;
+import com.nexus.sion.feature.techstack.command.domain.aggregate.TechStack;
+import com.nexus.sion.feature.techstack.command.repository.TechStackRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
+import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberRole;
+import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberStatus;
+import com.nexus.sion.feature.member.query.dto.response.FreelancerDetailResponse;
+import com.nexus.sion.feature.member.query.repository.FreelancerQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.nexus.sion.feature.project.command.application.util.FPScoreUtils.classifyComplexity;
+import static com.nexus.sion.feature.project.command.application.util.FPScoreUtils.getFpScore;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FreelancerCommandServiceImpl implements FreelancerCommandService {
+
+  private final FreelancerQueryRepository freelancerQueryRepository;
+  private final MemberRepository memberRepository;
+  private final FreelancerRepository freelancerRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  private final DeveloperTechStackRepository developerTechStackRepository;
+  private final DeveloperTechStackHistoryRepository developerTechStackHistoryRepository;
+  private final MemberScoreHistoryRepository memberScoreHistoryRepository;
+  private final FastApiClient fastApiClient;
+  private final TechStackRepository techStackRepository;
+
+  @Override
+  public void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile) {
+    FreelancerDetailResponse freelancer =
+        freelancerQueryRepository.getFreelancerDetail(freelancerId);
+
+    String rawPassword =
+        (freelancer.birthday() != null)
+            ? String.format(
+                "%02d%02d%02d",
+                freelancer.birthday().getYear() % 100,
+                freelancer.birthday().getMonthValue(),
+                freelancer.birthday().getDayOfMonth())
+            : "000000";
+
+    String encodedPassword = passwordEncoder.encode(rawPassword);
+
+    Member member = memberRepository
+            .findById(freelancer.freelancerId())
+            .orElseGet(() -> {
+              Member newMember =Member.builder()
+                      .employeeIdentificationNumber(freelancer.freelancerId())
+                      .employeeName(freelancer.name())
+                      .password(encodedPassword)
+                      .profileImageUrl(freelancer.profileImageUrl())
+                      .phoneNumber(freelancer.phoneNumber())
+                      .email(freelancer.email())
+                      .birthday(freelancer.birthday())
+                      .careerYears(freelancer.careerYears())
+                      .joinedAt(LocalDate.now())
+                      .role(MemberRole.OUTSIDER)
+                      .status(MemberStatus.AVAILABLE)
+                      .build();
+              return memberRepository.save(newMember);
+            });
+
+    memberRepository.save(member);
+
+    File tempFile;
+    List<FunctionScore> functions;
+    try {
+      tempFile = File.createTempFile("input_", ".pdf");
+      multipartFile.transferTo(tempFile);
+
+      functions = fastApiClient.requestFpFreelencerInference(tempFile);
+    } catch (IOException e) {
+      log.error("[FP 분석 실패] {}", e.getMessage(), e);
+      throw new BusinessException(ErrorCode.FP_ANALYZE_FAIL);
+    }
+
+    // FastAPI 분석 결과로 기술스택 점수 누적 계산
+    Map<String, Integer> techStackTotalScoreMap = new HashMap<>();
+    for (FunctionScore req : functions) {
+      String complexity = classifyComplexity(req.getFpType(), req.getDet(), req.getFtrOrRet());
+      int score = getFpScore(req.getFpType(), complexity);
+      int perStackScore = score / req.getStacks().size();
+      for (String stack : req.getStacks()) {
+        techStackTotalScoreMap.merge(stack, perStackScore, Integer::sum);
+      }
+    }
+
+    // 기술스택 및 이력 저장
+    for (Map.Entry<String, Integer> entry : techStackTotalScoreMap.entrySet()) {
+      String techStackName = entry.getKey();
+      int addedScore = entry.getValue();
+
+      techStackRepository.findById(techStackName)
+              .orElseGet(() -> techStackRepository.save(
+                      TechStack.builder().techStackName(techStackName).build()
+              ));
+
+      DeveloperTechStack stack = developerTechStackRepository
+              .findByEmployeeIdentificationNumberAndTechStackName(freelancer.freelancerId(), techStackName)
+              .orElseGet(() -> developerTechStackRepository.save(
+                      DeveloperTechStack.builder()
+                              .employeeIdentificationNumber(freelancer.freelancerId())
+                              .techStackName(techStackName)
+                              .totalScore(0)
+                              .build()
+              ));
+
+      developerTechStackHistoryRepository.save(
+              DeveloperTechStackHistory.builder()
+                      .addedScore(addedScore)
+                      .developerTechStackId(stack.getId())
+                      .build()
+      );
+
+      stack.setTotalScore(stack.getTotalScore() + addedScore);
+      developerTechStackRepository.save(stack);
+    }
+
+
+    //Member 점수 이력 갱신
+    int totalStackScore = developerTechStackRepository
+            .findAllByEmployeeIdentificationNumber(freelancer.freelancerId())
+            .stream()
+            .mapToInt(DeveloperTechStack::getTotalScore)
+            .sum();
+
+    MemberScoreHistory scoreHistory = memberScoreHistoryRepository
+            .findByEmployeeIdentificationNumber(freelancer.freelancerId())
+            .orElseGet(() -> MemberScoreHistory.builder()
+                    .employeeIdentificationNumber(freelancer.freelancerId())
+                    .totalCertificateScores(0)
+                    .totalTechStackScores(0)
+                    .build()
+            );
+    scoreHistory.setTotalTechStackScores(totalStackScore);
+    memberScoreHistoryRepository.save(scoreHistory);
+
+    freelancerRepository.deleteById(freelancer.freelancerId());
+  }
+}

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/DeveloperTechStackHistory.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/DeveloperTechStackHistory.java
@@ -22,7 +22,7 @@ public class DeveloperTechStackHistory extends BaseTimeEntity {
   @Column(name = "developer_tech_stack_id", nullable = false)
   private Long developerTechStackId;
 
-  @Column(name = "project_code", nullable = false)
+  @Column(name = "project_code")
   private String projectCode;
 
   @Column(name = "added_score", nullable = false)

--- a/src/main/java/com/nexus/sion/feature/project/command/application/dto/FunctionScore.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/dto/FunctionScore.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class FunctionScore {
   private String functionName;
   private String description;

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
@@ -208,11 +208,12 @@ public class ProjectCommandServiceImpl implements ProjectCommandService {
     // 기존에 project_fp_summary나 project_function_estimate가 있다면 삭제
     ProjectFpSummary fpSummary =
         projectFpSummaryRepository
-            .findByProjectCode(projectId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+            .findByProjectCode(projectId).orElse(null);
 
-    projectFunctionEstimateRepository.deleteByProjectFpSummaryId(fpSummary.getId());
-    projectFpSummaryRepository.deleteByProjectCode(projectId);
+    if (fpSummary != null) {
+      projectFunctionEstimateRepository.deleteByProjectFpSummaryId(fpSummary.getId());
+      projectFpSummaryRepository.deleteByProjectCode(projectId);
+    }
 
     Project project =
         projectRepository

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectEvaluateCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectEvaluateCommandServiceImpl.java
@@ -47,13 +47,11 @@ public class ProjectEvaluateCommandServiceImpl implements ProjectEvaluateCommand
       String complexity = classifyComplexity(req.getFpType(), req.getDet(), req.getFtrOrRet());
       int score = getFpScore(req.getFpType(), complexity);
 
-      // 균등 분배 방식: 스택 수만큼 나눔
       int perStackScore = score / req.getStacks().size();
       for (String stack : req.getStacks()) {
         techStackTotalScoreMap.merge(stack, perStackScore, Integer::sum); // stack이 일치하면 점수 합치기
       }
 
-      // FastAPI에 벡터 저장
       Map<String, Object> payload = new HashMap<>();
       payload.put("function_name", req.getFunctionName());
       payload.put("description", req.getDescription());
@@ -64,7 +62,6 @@ public class ProjectEvaluateCommandServiceImpl implements ProjectEvaluateCommand
       vectorPayloads.add(payload);
     }
 
-    // 기술스택 점수 저장
     for (Map.Entry<String, Integer> entry : techStackTotalScoreMap.entrySet()) {
       String techStackName = entry.getKey();
       int addedScore = entry.getValue();

--- a/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
@@ -45,12 +45,14 @@ public class DeveloperProjectWorkQueryServiceImpl implements DeveloperProjectWor
 
   @Override
   public ProjectInfoDto getProjectInfo(Long workId) {
-    return projectQueryRepository.findProjectInfoByWorkId(workId);
+    return null;
+//    return projectQueryRepository.findProjectInfoByWorkId(workId);
   }
 
   @Override
   public WorkInfoQueryDto getRequestDetailById(Long projectWorkId) {
-    return projectQueryRepository.findById(projectWorkId);
+    return null;
+//    return projectQueryRepository.findById(projectWorkId);
   }
 
   @Override

--- a/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
@@ -45,14 +45,12 @@ public class DeveloperProjectWorkQueryServiceImpl implements DeveloperProjectWor
 
   @Override
   public ProjectInfoDto getProjectInfo(Long workId) {
-    return null;
-//    return projectQueryRepository.findProjectInfoByWorkId(workId);
+    return projectQueryRepository.findProjectInfoByWorkId(workId);
   }
 
   @Override
   public WorkInfoQueryDto getRequestDetailById(Long projectWorkId) {
-    return null;
-//    return projectQueryRepository.findById(projectWorkId);
+    return projectQueryRepository.findById(projectWorkId);
   }
 
   @Override

--- a/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
@@ -60,38 +60,39 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
 
   public PageResponse<ProjectListResponse> getProjectsByEmployeeId(
       String employeeId, List<String> statuses, int page, int size) {
-    List<Project> pojos =
-        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
-    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
-
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-    List<ProjectListResponse> content =
-        pojos.stream()
-            .map(
-                p ->
-                    ProjectListResponse.builder()
-                        .projectCode(p.getProjectCode())
-                        .title(p.getTitle())
-                        .description(p.getDescription())
-                        .startDate(
-                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
-                        .endDate(
-                            p.getExpectedEndDate() != null
-                                ? p.getExpectedEndDate().format(formatter)
-                                : null)
-                        .period(
-                            p.getStartDate() != null && p.getExpectedEndDate() != null
-                                ? (int)
-                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
-                                : 0)
-                        .status(p.getStatus() != null ? p.getStatus().name() : null)
-                        .domainName(p.getDomainName())
-                        .hrCount(p.getNumberOfMembers())
-                        .analysisStatus(p.getAnalysisStatus())
-                        .build())
-            .toList();
-
-    return PageResponse.fromJooq(content, totalCount, page, size);
+//    List<Project> pojos =
+//        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
+//    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
+//
+//    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+//
+//    List<ProjectListResponse> content =
+//        pojos.stream()
+//            .map(
+//                p ->
+//                    ProjectListResponse.builder()
+//                        .projectCode(p.getProjectCode())
+//                        .title(p.getTitle())
+//                        .description(p.getDescription())
+//                        .startDate(
+//                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
+//                        .endDate(
+//                            p.getExpectedEndDate() != null
+//                                ? p.getExpectedEndDate().format(formatter)
+//                                : null)
+//                        .period(
+//                            p.getStartDate() != null && p.getExpectedEndDate() != null
+//                                ? (int)
+//                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
+//                                : 0)
+//                        .status(p.getStatus() != null ? p.getStatus().name() : null)
+//                        .domainName(p.getDomainName())
+//                        .hrCount(p.getNumberOfMembers())
+//                        .analysisStatus(p.getAnalysisStatus())
+//                        .build())
+//            .toList();
+//
+//    return PageResponse.fromJooq(content, totalCount, page, size);
+      return null;
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
@@ -29,6 +29,7 @@ public class SquadDetailResponse {
   private String description;
   private SquadOriginType origin;
   private Boolean isActive;
+  private String projectCode;
 
   @Getter
   @Builder

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -205,6 +205,7 @@ public class SquadQueryRepository {
         .isActive(isActive)
         .description(squad.get(SQUAD.DESCRIPTION))
         .origin(squad.get(SQUAD.ORIGIN_TYPE))
+        .projectCode(squad.get(SQUAD.PROJECT_CODE))
         .build();
   }
 }

--- a/src/main/java/com/nexus/sion/feature/techstack/command/domain/aggregate/TechStack.java
+++ b/src/main/java/com/nexus/sion/feature/techstack/command/domain/aggregate/TechStack.java
@@ -4,16 +4,15 @@ import jakarta.persistence.*;
 
 import com.nexus.sion.common.domain.BaseTimeEntity;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Table(name = "tech_stack")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
+@Builder
+@AllArgsConstructor
 public class TechStack extends BaseTimeEntity {
   // base entity : 생성일자, 수정일자 자동생성 및 업데이트 설정
   @Id

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,4 +94,5 @@ management:
 ai:
   fp-infer: http://localhost:8100/fp-infer
   embed-function: http://localhost:8100/fp-embed
+  fp-freelencer-infer: http://localhost:8100/fp-freelancer-infer
 


### PR DESCRIPTION
## 🪐 작업 내용
- 이력서 기반 점수 산정 기능 구현했습니다
- 현재는 컨트롤러로부터 PDF 파일 받아서 처리하고 있지만 추후에 이력서 url을 db로부터 조회한 기반으로 연결할 예정입니다. 

<br>

## ✅ 체크리스트
- [o]  기능 구현
- [x]  service mock 단위 테스트
- [x]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
