### PR TITLE
[feat] 개발자 자기계발 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/UserCertificateHistoryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/UserCertificateHistoryController.java
@@ -22,7 +22,7 @@ public class UserCertificateHistoryController {
   // 개발자 자격증 등록
   @PostMapping
   public ResponseEntity<ApiResponse<Void>> registerUserCertificate(
-      @PathVariable String employeeId, @RequestBody @Valid UserCertificateHistoryRequest request) {
+      @PathVariable String employeeId, @ModelAttribute @Valid UserCertificateHistoryRequest request) {
     userCertificateHistoryService.registerUserCertificate(employeeId, request);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
   }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/UserCertificateHistoryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/UserCertificateHistoryController.java
@@ -22,7 +22,8 @@ public class UserCertificateHistoryController {
   // 개발자 자격증 등록
   @PostMapping
   public ResponseEntity<ApiResponse<Void>> registerUserCertificate(
-      @PathVariable String employeeId, @ModelAttribute @Valid UserCertificateHistoryRequest request) {
+      @PathVariable String employeeId,
+      @ModelAttribute @Valid UserCertificateHistoryRequest request) {
     userCertificateHistoryService.registerUserCertificate(employeeId, request);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
   }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateRejectRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/CertificateRejectRequest.java
@@ -1,12 +1,12 @@
 package com.nexus.sion.feature.member.command.application.dto.request;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@NoArgsConstructor
 public class CertificateRejectRequest {
   private String rejectedReason;
-
-  public CertificateRejectRequest(String reason) {
-    this.rejectedReason = reason;
-  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/UserCertificateHistoryRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/UserCertificateHistoryRequest.java
@@ -5,8 +5,9 @@ import java.time.LocalDate;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import lombok.*;
 
 @Getter
 @Setter

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/UserCertificateHistoryRequest.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/request/UserCertificateHistoryRequest.java
@@ -6,8 +6,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -22,6 +24,6 @@ public class UserCertificateHistoryRequest {
   @NotNull(message = "취득일자는 필수입니다.")
   private LocalDate issueDate;
 
-  @NotBlank(message = "PDF 파일 URL은 필수입니다.")
-  private String pdfFileUrl;
+  @NotNull(message = "PDF 파일은 필수입니다.")
+  private MultipartFile pdfFileUrl;
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/UserCertificateHistoryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/UserCertificateHistoryServiceImpl.java
@@ -3,6 +3,7 @@ package com.nexus.sion.feature.member.command.application.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.nexus.sion.common.s3.service.DocumentS3Service;
 import org.springframework.stereotype.Service;
 
 import com.nexus.sion.exception.BusinessException;
@@ -25,6 +26,7 @@ public class UserCertificateHistoryServiceImpl implements UserCertificateHistory
 
   private final UserCertificateHistoryRepository userCertificateHistoryRepository;
   private final CertificateRepository certificateRepository;
+  private final DocumentS3Service documentS3Service;
 
   @Override
   @Transactional
@@ -34,12 +36,17 @@ public class UserCertificateHistoryServiceImpl implements UserCertificateHistory
             .findById(request.getCertificateName())
             .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
 
+    String prefix = "certificates";
+    String uploadedUrl = documentS3Service
+            .uploadFile(request.getPdfFileUrl(), prefix)
+            .getUrl();
+
     UserCertificateHistory history =
         UserCertificateHistory.builder()
             .certificateName(certificate.getCertificateName())
             .employeeIdentificationNumber(employeeId)
             .certificateStatus(CertificateStatus.PENDING)
-            .pdfFileUrl(request.getPdfFileUrl())
+                .pdfFileUrl(uploadedUrl)
             .issueDate(request.getIssueDate())
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/UserCertificateHistoryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/UserCertificateHistoryServiceImpl.java
@@ -3,9 +3,10 @@ package com.nexus.sion.feature.member.command.application.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.nexus.sion.common.s3.service.DocumentS3Service;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.nexus.sion.common.s3.service.DocumentS3Service;
 import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.member.command.application.dto.request.CertificateRejectRequest;
@@ -18,7 +19,6 @@ import com.nexus.sion.feature.member.command.domain.repository.UserCertificateHi
 import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -37,16 +37,14 @@ public class UserCertificateHistoryServiceImpl implements UserCertificateHistory
             .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
 
     String prefix = "certificates";
-    String uploadedUrl = documentS3Service
-            .uploadFile(request.getPdfFileUrl(), prefix)
-            .getUrl();
+    String uploadedUrl = documentS3Service.uploadFile(request.getPdfFileUrl(), prefix).getUrl();
 
     UserCertificateHistory history =
         UserCertificateHistory.builder()
             .certificateName(certificate.getCertificateName())
             .employeeIdentificationNumber(employeeId)
             .certificateStatus(CertificateStatus.PENDING)
-                .pdfFileUrl(uploadedUrl)
+            .pdfFileUrl(uploadedUrl)
             .issueDate(request.getIssueDate())
             .createdAt(LocalDateTime.now())
             .updatedAt(LocalDateTime.now())

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/MemberScoreQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/MemberScoreQueryController.java
@@ -1,12 +1,12 @@
 package com.nexus.sion.feature.member.query.controller;
 
-import com.nexus.sion.common.dto.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nexus.sion.common.dto.ApiResponse;
 import com.nexus.sion.feature.member.query.dto.response.MemberScoreHistoryResponse;
 import com.nexus.sion.feature.member.query.service.MemberScoreHistoryQueryService;
 

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
@@ -1,0 +1,29 @@
+package com.nexus.sion.feature.member.query.controller;
+
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+import com.nexus.sion.feature.member.query.service.UserCertificateHistoryQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user-certificates")
+public class UserCertificateHistoryQueryController {
+
+  private final UserCertificateHistoryQueryService userCertificateHistoryQueryService;
+
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<List<UserCertificateHistoryResponse>>> getMyCertificates(
+      @AuthenticationPrincipal Long memberId
+  ) {
+    List<UserCertificateHistoryResponse> result = userCertificateHistoryQueryService.getMyCertificates(memberId);
+    return ResponseEntity.ok(ApiResponse.success(result));
+  }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
@@ -1,16 +1,16 @@
 package com.nexus.sion.feature.member.query.controller;
 
-import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
-import com.nexus.sion.feature.member.query.service.UserCertificateHistoryQueryService;
-
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import com.nexus.sion.common.dto.ApiResponse;
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+import com.nexus.sion.feature.member.query.service.UserCertificateHistoryQueryService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,9 +21,9 @@ public class UserCertificateHistoryQueryController {
 
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<List<UserCertificateHistoryResponse>>> getMyCertificates(
-      @AuthenticationPrincipal Long memberId
-  ) {
-    List<UserCertificateHistoryResponse> result = userCertificateHistoryQueryService.getMyCertificates(memberId);
+      @AuthenticationPrincipal Long memberId) {
+    List<UserCertificateHistoryResponse> result =
+        userCertificateHistoryQueryService.getMyCertificates(memberId);
     return ResponseEntity.ok(ApiResponse.success(result));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.common.dto.ApiResponse;
@@ -21,7 +22,8 @@ public class UserCertificateHistoryQueryController {
 
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<List<UserCertificateHistoryResponse>>> getMyCertificates(
-      @AuthenticationPrincipal String memberId) {
+      @AuthenticationPrincipal UserDetails userDetails) {
+    String memberId = userDetails.getUsername();
     List<UserCertificateHistoryResponse> result =
         userCertificateHistoryQueryService.getMyCertificates(memberId);
     return ResponseEntity.ok(ApiResponse.success(result));

--- a/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/UserCertificateHistoryQueryController.java
@@ -21,7 +21,7 @@ public class UserCertificateHistoryQueryController {
 
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<List<UserCertificateHistoryResponse>>> getMyCertificates(
-      @AuthenticationPrincipal Long memberId) {
+      @AuthenticationPrincipal String memberId) {
     List<UserCertificateHistoryResponse> result =
         userCertificateHistoryQueryService.getMyCertificates(memberId);
     return ResponseEntity.ok(ApiResponse.success(result));

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
@@ -1,0 +1,54 @@
+package com.nexus.sion.feature.member.query.repository;
+
+import static com.example.jooq.generated.tables.UserCertificateHistory.USER_CERTIFICATE_HISTORY;
+import static com.example.jooq.generated.tables.Certificate.CERTIFICATE;
+import static com.example.jooq.generated.tables.Member.MEMBER;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCertificateHistoryQueryRepository {
+
+    private final DSLContext dsl;
+
+    public List<UserCertificateHistoryResponse> findByMemberId(Long memberId) {
+        return dsl.select(
+                        USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID,
+                        CERTIFICATE.CERTIFICATE_NAME,
+                        CERTIFICATE.ISSUING_ORGANIZATION,
+                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                        MEMBER.EMPLOYEE_NAME,
+                        USER_CERTIFICATE_HISTORY.ISSUE_DATE,
+                        USER_CERTIFICATE_HISTORY.PDF_FILE_URL,
+                        USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS,
+                        USER_CERTIFICATE_HISTORY.REJECTED_REASON,
+                        USER_CERTIFICATE_HISTORY.CREATED_AT,
+                        USER_CERTIFICATE_HISTORY.UPDATED_AT
+                )
+                .from(USER_CERTIFICATE_HISTORY)
+                .join(CERTIFICATE).on(USER_CERTIFICATE_HISTORY.CERTIFICATE_NAME.eq(CERTIFICATE.CERTIFICATE_NAME))
+                .join(MEMBER).on(USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .where(USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .fetch(record -> UserCertificateHistoryResponse.builder()
+                        .userCertificateHistoryId(record.get(USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID))
+                        .certificateName(record.get(CERTIFICATE.CERTIFICATE_NAME))
+                        .issuingOrganization(record.get(CERTIFICATE.ISSUING_ORGANIZATION))
+                        .employeeIdentificationNumber(record.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+                        .employeeName(record.get(MEMBER.EMPLOYEE_NAME))
+                        .issueDate(record.get(USER_CERTIFICATE_HISTORY.ISSUE_DATE).toLocalDate())
+                        .pdfFileUrl(record.get(USER_CERTIFICATE_HISTORY.PDF_FILE_URL))
+                        .certificateStatus(record.get(USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS).name())
+                        .rejectedReason(record.get(USER_CERTIFICATE_HISTORY.REJECTED_REASON))
+                        .createdAt(record.get(USER_CERTIFICATE_HISTORY.CREATED_AT))
+                        .updatedAt(record.get(USER_CERTIFICATE_HISTORY.UPDATED_AT))
+                        .build()
+                );
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
@@ -39,8 +39,9 @@ public class UserCertificateHistoryQueryRepository {
         .on(
             USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
                 MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-            .where(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(memberId))
-
+            .where(
+                    USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
+                            MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
             .fetch(
             record ->
                 UserCertificateHistoryResponse.builder()

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
@@ -19,7 +19,7 @@ public class UserCertificateHistoryQueryRepository {
 
   private final DSLContext dsl;
 
-  public List<UserCertificateHistoryResponse> findByMemberId(Long memberId) {
+  public List<UserCertificateHistoryResponse> findByMemberId(String memberId) {
     return dsl.select(
             USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID,
             CERTIFICATE.CERTIFICATE_NAME,
@@ -39,10 +39,9 @@ public class UserCertificateHistoryQueryRepository {
         .on(
             USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
                 MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-        .where(
-            USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
-                MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-        .fetch(
+            .where(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(memberId))
+
+            .fetch(
             record ->
                 UserCertificateHistoryResponse.builder()
                     .userCertificateHistoryId(

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/UserCertificateHistoryQueryRepository.java
@@ -1,54 +1,63 @@
 package com.nexus.sion.feature.member.query.repository;
 
-import static com.example.jooq.generated.tables.UserCertificateHistory.USER_CERTIFICATE_HISTORY;
 import static com.example.jooq.generated.tables.Certificate.CERTIFICATE;
 import static com.example.jooq.generated.tables.Member.MEMBER;
+import static com.example.jooq.generated.tables.UserCertificateHistory.USER_CERTIFICATE_HISTORY;
 
 import java.util.List;
 
-import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Repository;
 
 import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
 
+import lombok.RequiredArgsConstructor;
+
 @Repository
 @RequiredArgsConstructor
 public class UserCertificateHistoryQueryRepository {
 
-    private final DSLContext dsl;
+  private final DSLContext dsl;
 
-    public List<UserCertificateHistoryResponse> findByMemberId(Long memberId) {
-        return dsl.select(
-                        USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID,
-                        CERTIFICATE.CERTIFICATE_NAME,
-                        CERTIFICATE.ISSUING_ORGANIZATION,
-                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
-                        MEMBER.EMPLOYEE_NAME,
-                        USER_CERTIFICATE_HISTORY.ISSUE_DATE,
-                        USER_CERTIFICATE_HISTORY.PDF_FILE_URL,
-                        USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS,
-                        USER_CERTIFICATE_HISTORY.REJECTED_REASON,
-                        USER_CERTIFICATE_HISTORY.CREATED_AT,
-                        USER_CERTIFICATE_HISTORY.UPDATED_AT
-                )
-                .from(USER_CERTIFICATE_HISTORY)
-                .join(CERTIFICATE).on(USER_CERTIFICATE_HISTORY.CERTIFICATE_NAME.eq(CERTIFICATE.CERTIFICATE_NAME))
-                .join(MEMBER).on(USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-                .where(USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-                .fetch(record -> UserCertificateHistoryResponse.builder()
-                        .userCertificateHistoryId(record.get(USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID))
-                        .certificateName(record.get(CERTIFICATE.CERTIFICATE_NAME))
-                        .issuingOrganization(record.get(CERTIFICATE.ISSUING_ORGANIZATION))
-                        .employeeIdentificationNumber(record.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
-                        .employeeName(record.get(MEMBER.EMPLOYEE_NAME))
-                        .issueDate(record.get(USER_CERTIFICATE_HISTORY.ISSUE_DATE).toLocalDate())
-                        .pdfFileUrl(record.get(USER_CERTIFICATE_HISTORY.PDF_FILE_URL))
-                        .certificateStatus(record.get(USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS).name())
-                        .rejectedReason(record.get(USER_CERTIFICATE_HISTORY.REJECTED_REASON))
-                        .createdAt(record.get(USER_CERTIFICATE_HISTORY.CREATED_AT))
-                        .updatedAt(record.get(USER_CERTIFICATE_HISTORY.UPDATED_AT))
-                        .build()
-                );
-    }
+  public List<UserCertificateHistoryResponse> findByMemberId(Long memberId) {
+    return dsl.select(
+            USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID,
+            CERTIFICATE.CERTIFICATE_NAME,
+            CERTIFICATE.ISSUING_ORGANIZATION,
+            MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+            MEMBER.EMPLOYEE_NAME,
+            USER_CERTIFICATE_HISTORY.ISSUE_DATE,
+            USER_CERTIFICATE_HISTORY.PDF_FILE_URL,
+            USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS,
+            USER_CERTIFICATE_HISTORY.REJECTED_REASON,
+            USER_CERTIFICATE_HISTORY.CREATED_AT,
+            USER_CERTIFICATE_HISTORY.UPDATED_AT)
+        .from(USER_CERTIFICATE_HISTORY)
+        .join(CERTIFICATE)
+        .on(USER_CERTIFICATE_HISTORY.CERTIFICATE_NAME.eq(CERTIFICATE.CERTIFICATE_NAME))
+        .join(MEMBER)
+        .on(
+            USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
+                MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+        .where(
+            USER_CERTIFICATE_HISTORY.EMPLOYEE_IDENTIFICATION_NUMBER.eq(
+                MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+        .fetch(
+            record ->
+                UserCertificateHistoryResponse.builder()
+                    .userCertificateHistoryId(
+                        record.get(USER_CERTIFICATE_HISTORY.USER_CERTIFICATE_HISTORY_ID))
+                    .certificateName(record.get(CERTIFICATE.CERTIFICATE_NAME))
+                    .issuingOrganization(record.get(CERTIFICATE.ISSUING_ORGANIZATION))
+                    .employeeIdentificationNumber(record.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+                    .employeeName(record.get(MEMBER.EMPLOYEE_NAME))
+                    .issueDate(record.get(USER_CERTIFICATE_HISTORY.ISSUE_DATE).toLocalDate())
+                    .pdfFileUrl(record.get(USER_CERTIFICATE_HISTORY.PDF_FILE_URL))
+                    .certificateStatus(
+                        record.get(USER_CERTIFICATE_HISTORY.CERTIFICATE_STATUS).name())
+                    .rejectedReason(record.get(USER_CERTIFICATE_HISTORY.REJECTED_REASON))
+                    .createdAt(record.get(USER_CERTIFICATE_HISTORY.CREATED_AT))
+                    .updatedAt(record.get(USER_CERTIFICATE_HISTORY.UPDATED_AT))
+                    .build());
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/MemberScoreHistoryQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/MemberScoreHistoryQueryServiceImpl.java
@@ -2,11 +2,11 @@ package com.nexus.sion.feature.member.query.service;
 
 import java.time.LocalDateTime;
 
+import org.springframework.stereotype.Service;
+
 import com.example.jooq.generated.tables.records.MemberScoreHistoryRecord;
 import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
-import org.springframework.stereotype.Service;
-
 import com.nexus.sion.feature.member.query.dto.response.MemberScoreHistoryResponse;
 import com.nexus.sion.feature.member.query.repository.MemberScoreQueryRepository;
 
@@ -48,11 +48,12 @@ public class MemberScoreHistoryQueryServiceImpl implements MemberScoreHistoryQue
         latestPrevRecord = prevTech;
       } else {
         latestPrevRecord =
-                prevTech.getCreatedAt().isAfter(prevCert.getCreatedAt()) ? prevTech : prevCert;
+            prevTech.getCreatedAt().isAfter(prevCert.getCreatedAt()) ? prevTech : prevCert;
       }
       if (latestPrevRecord != null) {
         previousTotalScore =
-                latestPrevRecord.getTotalTechStackScores() + latestPrevRecord.getTotalCertificateScores();
+            latestPrevRecord.getTotalTechStackScores()
+                + latestPrevRecord.getTotalCertificateScores();
         previousTotalScoreDate = latestPrevRecord.getCreatedAt();
       }
     }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
@@ -1,9 +1,9 @@
 package com.nexus.sion.feature.member.query.service;
 
-import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
-
 import java.util.List;
 
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+
 public interface UserCertificateHistoryQueryService {
-    List<UserCertificateHistoryResponse> getMyCertificates(Long memberId);
+  List<UserCertificateHistoryResponse> getMyCertificates(Long memberId);
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
@@ -1,0 +1,9 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+
+import java.util.List;
+
+public interface UserCertificateHistoryQueryService {
+    List<UserCertificateHistoryResponse> getMyCertificates(Long memberId);
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryService.java
@@ -5,5 +5,5 @@ import java.util.List;
 import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
 
 public interface UserCertificateHistoryQueryService {
-  List<UserCertificateHistoryResponse> getMyCertificates(Long memberId);
+  List<UserCertificateHistoryResponse> getMyCertificates(String memberId);
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.nexus.sion.feature.member.query.service;
+
+import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
+import com.nexus.sion.feature.member.query.repository.UserCertificateHistoryQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserCertificateHistoryQueryServiceImpl implements UserCertificateHistoryQueryService {
+
+    private final UserCertificateHistoryQueryRepository userCertificateHistoryQueryRepository;
+
+    @Override
+    public List<UserCertificateHistoryResponse> getMyCertificates(Long memberId) {
+        return userCertificateHistoryQueryRepository.findByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
@@ -1,21 +1,22 @@
 package com.nexus.sion.feature.member.query.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
 import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
 import com.nexus.sion.feature.member.query.repository.UserCertificateHistoryQueryRepository;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserCertificateHistoryQueryServiceImpl implements UserCertificateHistoryQueryService {
 
-    private final UserCertificateHistoryQueryRepository userCertificateHistoryQueryRepository;
+  private final UserCertificateHistoryQueryRepository userCertificateHistoryQueryRepository;
 
-    @Override
-    public List<UserCertificateHistoryResponse> getMyCertificates(Long memberId) {
-        return userCertificateHistoryQueryRepository.findByMemberId(memberId);
-    }
+  @Override
+  public List<UserCertificateHistoryResponse> getMyCertificates(Long memberId) {
+    return userCertificateHistoryQueryRepository.findByMemberId(memberId);
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/UserCertificateHistoryQueryServiceImpl.java
@@ -16,7 +16,7 @@ public class UserCertificateHistoryQueryServiceImpl implements UserCertificateHi
   private final UserCertificateHistoryQueryRepository userCertificateHistoryQueryRepository;
 
   @Override
-  public List<UserCertificateHistoryResponse> getMyCertificates(Long memberId) {
+  public List<UserCertificateHistoryResponse> getMyCertificates(String  memberId) {
     return userCertificateHistoryQueryRepository.findByMemberId(memberId);
   }
 }


### PR DESCRIPTION
## 🛰️ Issue
Closes #291
Closes #292 

<br>

## 🪐 작업 내용
개발자 보유 자격증 등록 기능 구현
개발자보유 자격증 전체 조회 API 구현
관리자 자격증 승인/반려 처리 API 구현
S3 연동 로직 추가

<br>

## ✅ 체크리스트
- [x]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [x  spotless apply 적용 여부
      `./gradlew spotlessApply`
