### PR TITLE
[Feat] 프로젝트 인원 대체 추천 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/exception/ErrorCode.java
+++ b/src/main/java/com/nexus/sion/exception/ErrorCode.java
@@ -76,6 +76,9 @@ public enum ErrorCode {
   INSUFFICIENT_TOTAL_MEMBER("40013", "프로젝트에 필요한 인원수가 충족되지 않았습니다", HttpStatus.BAD_REQUEST),
   EXCEED_PROJECT_BUDGET("40014", "프로젝트 예산 상한선을 충족하지 못한 스쿼드입니다", HttpStatus.BAD_REQUEST),
   EXCEED_PROJECT_DURATION("40015", "프로젝트 기간 상한선을 충족하지 못한 스쿼드입니다", HttpStatus.BAD_REQUEST),
+  INVALID_SQUAD_MEMBER("40016","스쿼드에 포함되지 않는 멤버입니다",HttpStatus.BAD_REQUEST ),
+  INVALID_LEADER_REPLACEMENT("40017", "리더는 대체될 수 없습니다", HttpStatus.BAD_REQUEST),
+  INVALID_EXIST_MEMBER_REPLACEMENT("40018", "이미 배정된 멤버로 대체할 수 없습니다", HttpStatus.BAD_REQUEST),
 
   // techstack
   TECH_STACK_NOT_FOUND("50001", "해당 기술스택을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/nexus/sion/exception/ErrorCode.java
+++ b/src/main/java/com/nexus/sion/exception/ErrorCode.java
@@ -87,6 +87,7 @@ public enum ErrorCode {
   // FP
   FP_NOT_FOUND("70001", "총 FP 포인트가 없는 프로젝트 평가입니다.", HttpStatus.NOT_FOUND),
   PROJECT_ANALYSIS_ALREADY_IN_PROGRESS("70002", "이미 분석이 진행 중이거나 완료된 프로젝트입니다.", HttpStatus.CONFLICT),
+  FP_ANALYZE_FAIL("70003","FP 분석에 실패했습니다.", HttpStatus.CONFLICT ),
 
   // developer project work
   WORK_HISTORY_NOT_FOUND("80001", "작업 이력이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
@@ -94,8 +95,7 @@ public enum ErrorCode {
   WORK_NOT_FOUND("80003", "해당 개발자 프로젝트 작업이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
   // notification
-  NOTIFICATION_NOT_FOUND("90001", "해당 알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-  ;
+  NOTIFICATION_NOT_FOUND("90001", "해당 알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
   private final String code;
   private final String message;
   private final HttpStatus httpStatus;

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
@@ -1,26 +1,24 @@
 package com.nexus.sion.feature.member.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.nexus.sion.common.dto.ApiResponse;
-import com.nexus.sion.feature.member.command.application.service.FreelancerCommandService;
+import com.nexus.sion.feature.member.command.application.service.FreelancerCommandServiceImpl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/freelancers")
 public class FreelancerCommandController {
 
-  private final FreelancerCommandService freelancerCommandService;
+  private final FreelancerCommandServiceImpl freelancerCommandService;
 
   @PostMapping("/{freelancerId}/register")
-  public ResponseEntity<ApiResponse<Void>> registerAsMember(@PathVariable String freelancerId) {
-    freelancerCommandService.registerFreelancerAsMember(freelancerId);
+  public ResponseEntity<ApiResponse<Void>> registerAsMember(@PathVariable String freelancerId, @RequestParam("file") MultipartFile multipartFile) {
+    freelancerCommandService.registerFreelancerAsMember(freelancerId, multipartFile);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/dto/response/FreelencerFpInferResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/dto/response/FreelencerFpInferResponse.java
@@ -1,0 +1,13 @@
+package com.nexus.sion.feature.member.command.application.dto.response;
+
+import com.nexus.sion.feature.project.command.application.dto.FunctionScore;
+import lombok.Data;
+import lombok.ToString;
+
+import java.util.List;
+
+@Data
+@ToString
+public class FreelencerFpInferResponse {
+    private List<FunctionScore> functions;
+}

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
@@ -1,60 +1,7 @@
 package com.nexus.sion.feature.member.command.application.service;
 
-import java.time.LocalDate;
+import org.springframework.web.multipart.MultipartFile;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
-import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
-import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberRole;
-import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberStatus;
-import com.nexus.sion.feature.member.command.domain.repository.FreelancerRepository;
-import com.nexus.sion.feature.member.command.domain.repository.MemberRepository;
-import com.nexus.sion.feature.member.query.dto.response.FreelancerDetailResponse;
-import com.nexus.sion.feature.member.query.repository.FreelancerQueryRepository;
-
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class FreelancerCommandService {
-
-  private final FreelancerQueryRepository freelancerQueryRepository;
-  private final MemberRepository memberRepository;
-  private final FreelancerRepository freelancerRepository;
-  private final PasswordEncoder passwordEncoder;
-
-  public void registerFreelancerAsMember(String freelancerId) {
-    FreelancerDetailResponse freelancer =
-        freelancerQueryRepository.getFreelancerDetail(freelancerId);
-
-    String rawPassword =
-        (freelancer.birthday() != null)
-            ? String.format(
-                "%02d%02d%02d",
-                freelancer.birthday().getYear() % 100,
-                freelancer.birthday().getMonthValue(),
-                freelancer.birthday().getDayOfMonth())
-            : "000000";
-
-    String encodedPassword = passwordEncoder.encode(rawPassword);
-
-    Member member =
-        Member.builder()
-            .employeeIdentificationNumber(freelancer.freelancerId())
-            .employeeName(freelancer.name())
-            .password(encodedPassword)
-            .profileImageUrl(freelancer.profileImageUrl())
-            .phoneNumber(freelancer.phoneNumber())
-            .email(freelancer.email())
-            .birthday(freelancer.birthday())
-            .careerYears(freelancer.careerYears())
-            .joinedAt(LocalDate.now())
-            .role(MemberRole.OUTSIDER)
-            .status(MemberStatus.AVAILABLE)
-            .build();
-
-    memberRepository.save(member);
-    freelancerRepository.deleteById(freelancer.freelancerId());
-  }
+public interface FreelancerCommandService {
+    void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile);
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
@@ -1,0 +1,166 @@
+package com.nexus.sion.feature.member.command.application.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.nexus.sion.common.fastapi.FastApiClient;
+import com.nexus.sion.exception.BusinessException;
+import com.nexus.sion.exception.ErrorCode;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.DeveloperTechStack;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.DeveloperTechStackHistory;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.MemberScoreHistory;
+import com.nexus.sion.feature.member.command.domain.repository.*;
+import com.nexus.sion.feature.project.command.application.dto.FunctionScore;
+import com.nexus.sion.feature.techstack.command.domain.aggregate.TechStack;
+import com.nexus.sion.feature.techstack.command.repository.TechStackRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
+import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberRole;
+import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberStatus;
+import com.nexus.sion.feature.member.query.dto.response.FreelancerDetailResponse;
+import com.nexus.sion.feature.member.query.repository.FreelancerQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.nexus.sion.feature.project.command.application.util.FPScoreUtils.classifyComplexity;
+import static com.nexus.sion.feature.project.command.application.util.FPScoreUtils.getFpScore;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class FreelancerCommandServiceImpl implements FreelancerCommandService {
+
+  private final FreelancerQueryRepository freelancerQueryRepository;
+  private final MemberRepository memberRepository;
+  private final FreelancerRepository freelancerRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  private final DeveloperTechStackRepository developerTechStackRepository;
+  private final DeveloperTechStackHistoryRepository developerTechStackHistoryRepository;
+  private final MemberScoreHistoryRepository memberScoreHistoryRepository;
+  private final FastApiClient fastApiClient;
+  private final TechStackRepository techStackRepository;
+
+  @Override
+  public void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile) {
+    FreelancerDetailResponse freelancer =
+        freelancerQueryRepository.getFreelancerDetail(freelancerId);
+
+    String rawPassword =
+        (freelancer.birthday() != null)
+            ? String.format(
+                "%02d%02d%02d",
+                freelancer.birthday().getYear() % 100,
+                freelancer.birthday().getMonthValue(),
+                freelancer.birthday().getDayOfMonth())
+            : "000000";
+
+    String encodedPassword = passwordEncoder.encode(rawPassword);
+
+    Member member = memberRepository
+            .findById(freelancer.freelancerId())
+            .orElseGet(() -> {
+              Member newMember =Member.builder()
+                      .employeeIdentificationNumber(freelancer.freelancerId())
+                      .employeeName(freelancer.name())
+                      .password(encodedPassword)
+                      .profileImageUrl(freelancer.profileImageUrl())
+                      .phoneNumber(freelancer.phoneNumber())
+                      .email(freelancer.email())
+                      .birthday(freelancer.birthday())
+                      .careerYears(freelancer.careerYears())
+                      .joinedAt(LocalDate.now())
+                      .role(MemberRole.OUTSIDER)
+                      .status(MemberStatus.AVAILABLE)
+                      .build();
+              return memberRepository.save(newMember);
+            });
+
+    memberRepository.save(member);
+
+    File tempFile;
+    List<FunctionScore> functions;
+    try {
+      tempFile = File.createTempFile("input_", ".pdf");
+      multipartFile.transferTo(tempFile);
+
+      functions = fastApiClient.requestFpFreelencerInference(tempFile);
+    } catch (IOException e) {
+      log.error("[FP 분석 실패] {}", e.getMessage(), e);
+      throw new BusinessException(ErrorCode.FP_ANALYZE_FAIL);
+    }
+
+    // FastAPI 분석 결과로 기술스택 점수 누적 계산
+    Map<String, Integer> techStackTotalScoreMap = new HashMap<>();
+    for (FunctionScore req : functions) {
+      String complexity = classifyComplexity(req.getFpType(), req.getDet(), req.getFtrOrRet());
+      int score = getFpScore(req.getFpType(), complexity);
+      int perStackScore = score / req.getStacks().size();
+      for (String stack : req.getStacks()) {
+        techStackTotalScoreMap.merge(stack, perStackScore, Integer::sum);
+      }
+    }
+
+    // 기술스택 및 이력 저장
+    for (Map.Entry<String, Integer> entry : techStackTotalScoreMap.entrySet()) {
+      String techStackName = entry.getKey();
+      int addedScore = entry.getValue();
+
+      techStackRepository.findById(techStackName)
+              .orElseGet(() -> techStackRepository.save(
+                      TechStack.builder().techStackName(techStackName).build()
+              ));
+
+      DeveloperTechStack stack = developerTechStackRepository
+              .findByEmployeeIdentificationNumberAndTechStackName(freelancer.freelancerId(), techStackName)
+              .orElseGet(() -> developerTechStackRepository.save(
+                      DeveloperTechStack.builder()
+                              .employeeIdentificationNumber(freelancer.freelancerId())
+                              .techStackName(techStackName)
+                              .totalScore(0)
+                              .build()
+              ));
+
+      developerTechStackHistoryRepository.save(
+              DeveloperTechStackHistory.builder()
+                      .addedScore(addedScore)
+                      .developerTechStackId(stack.getId())
+                      .build()
+      );
+
+      stack.setTotalScore(stack.getTotalScore() + addedScore);
+      developerTechStackRepository.save(stack);
+    }
+
+
+    //Member 점수 이력 갱신
+    int totalStackScore = developerTechStackRepository
+            .findAllByEmployeeIdentificationNumber(freelancer.freelancerId())
+            .stream()
+            .mapToInt(DeveloperTechStack::getTotalScore)
+            .sum();
+
+    MemberScoreHistory scoreHistory = memberScoreHistoryRepository
+            .findByEmployeeIdentificationNumber(freelancer.freelancerId())
+            .orElseGet(() -> MemberScoreHistory.builder()
+                    .employeeIdentificationNumber(freelancer.freelancerId())
+                    .totalCertificateScores(0)
+                    .totalTechStackScores(0)
+                    .build()
+            );
+    scoreHistory.setTotalTechStackScores(totalStackScore);
+    memberScoreHistoryRepository.save(scoreHistory);
+
+    freelancerRepository.deleteById(freelancer.freelancerId());
+  }
+}

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/DeveloperTechStackHistory.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/DeveloperTechStackHistory.java
@@ -22,7 +22,7 @@ public class DeveloperTechStackHistory extends BaseTimeEntity {
   @Column(name = "developer_tech_stack_id", nullable = false)
   private Long developerTechStackId;
 
-  @Column(name = "project_code", nullable = false)
+  @Column(name = "project_code")
   private String projectCode;
 
   @Column(name = "added_score", nullable = false)

--- a/src/main/java/com/nexus/sion/feature/project/command/application/controller/ProjectCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/controller/ProjectCommandController.java
@@ -1,5 +1,6 @@
 package com.nexus.sion.feature.project.command.application.controller;
 
+import com.nexus.sion.feature.project.command.application.dto.request.SquadReplacementRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -59,5 +60,11 @@ public class ProjectCommandController {
 
     projectCommandService.analyzeProject(projectCode, multipartFile, userDetails.getUsername());
     return ResponseEntity.accepted().build();
+  }
+
+  @PutMapping("/squad/replacement")
+  public ResponseEntity<ApiResponse<Void>> replaceSquadMember(@RequestBody SquadReplacementRequest request) {
+    projectCommandService.replaceMember(request);
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/project/command/application/dto/FunctionScore.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/dto/FunctionScore.java
@@ -8,6 +8,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class FunctionScore {
   private String functionName;
   private String description;

--- a/src/main/java/com/nexus/sion/feature/project/command/application/dto/request/SquadReplacementRequest.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/dto/request/SquadReplacementRequest.java
@@ -1,0 +1,16 @@
+package com.nexus.sion.feature.project.command.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SquadReplacementRequest {
+    @NotBlank(message = "스쿼드 코드는 필수입니다.")
+    private String squadCode;
+    @NotBlank(message = "대체 대상 사원 번호는 필수입니다.")
+    private String oldEmployeeId;
+    @NotBlank(message = "보충 대상 사원 번호는 필수입니다.")
+    private String newEmployeeId;
+}

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandService.java
@@ -2,6 +2,7 @@ package com.nexus.sion.feature.project.command.application.service;
 
 import java.util.Map;
 
+import com.nexus.sion.feature.project.command.application.dto.request.SquadReplacementRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.nexus.sion.feature.project.command.application.dto.request.ProjectRegisterRequest;
@@ -22,4 +23,6 @@ public interface ProjectCommandService {
 
   void analyzeProject(
       String projectId, MultipartFile multipartFile, String employeeIdentificationNumber);
+
+    void replaceMember(SquadReplacementRequest request);
 }

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
@@ -208,11 +208,12 @@ public class ProjectCommandServiceImpl implements ProjectCommandService {
     // 기존에 project_fp_summary나 project_function_estimate가 있다면 삭제
     ProjectFpSummary fpSummary =
         projectFpSummaryRepository
-            .findByProjectCode(projectId)
-            .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
+            .findByProjectCode(projectId).orElse(null);
 
-    projectFunctionEstimateRepository.deleteByProjectFpSummaryId(fpSummary.getId());
-    projectFpSummaryRepository.deleteByProjectCode(projectId);
+    if (fpSummary != null) {
+      projectFunctionEstimateRepository.deleteByProjectFpSummaryId(fpSummary.getId());
+      projectFpSummaryRepository.deleteByProjectCode(projectId);
+    }
 
     Project project =
         projectRepository

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
@@ -3,8 +3,14 @@ package com.nexus.sion.feature.project.command.application.service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Member;
+import com.nexus.sion.feature.member.command.domain.aggregate.enums.MemberStatus;
+import com.nexus.sion.feature.member.command.domain.repository.MemberRepository;
+import com.nexus.sion.feature.project.command.application.dto.request.SquadReplacementRequest;
+import com.nexus.sion.feature.squad.command.domain.aggregate.entity.Squad;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -46,6 +52,7 @@ public class ProjectCommandServiceImpl implements ProjectCommandService {
   private final ProjectFpSummaryRepository projectFpSummaryRepository;
 
   private final DeveloperProjectWorkRepository developerProjectWorkRepository;
+  private final MemberRepository memberRepository;
 
   @Override
   public ProjectRegisterResponse registerProject(ProjectRegisterRequest request) {
@@ -234,6 +241,52 @@ public class ProjectCommandServiceImpl implements ProjectCommandService {
               notifyFPAnalysisFailure(employeeIdentificationNumber, projectId);
               return null;
             });
+  }
+
+  @Override
+  public void replaceMember(SquadReplacementRequest request) {
+
+    Squad existSquad = squadCommandRepository.findById(request.getSquadCode()).orElseThrow(
+            () -> new BusinessException(ErrorCode.SQUAD_NOT_FOUND)
+    );
+
+
+    SquadEmployee existsMember = squadEmployeeCommandRepository.findBySquadCodeAndEmployeeIdentificationNumber(
+            request.getSquadCode(), request.getOldEmployeeId()).orElseThrow(
+            () -> new BusinessException(ErrorCode.SQUAD_NOT_FOUND)
+    );
+
+    if(existsMember.isLeader()){
+      throw new BusinessException(ErrorCode.INVALID_LEADER_REPLACEMENT);
+    }
+
+    squadEmployeeCommandRepository.deleteBySquadCodeAndEmployeeIdentificationNumber(
+            request.getSquadCode(),
+            request.getOldEmployeeId()
+    );
+
+    boolean existsNew = squadEmployeeCommandRepository.existsBySquadCodeAndEmployeeIdentificationNumber(
+            request.getSquadCode(), request.getNewEmployeeId());
+
+    if (existsNew) {
+      throw new BusinessException(ErrorCode.INVALID_EXIST_MEMBER_REPLACEMENT);
+    }
+
+    Member targetMember = memberRepository.findById(request.getNewEmployeeId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+    if (targetMember.getStatus() != MemberStatus.AVAILABLE) {
+      throw new BusinessException(ErrorCode.INVALID_MEMBER_STATUS);
+    }
+
+    SquadEmployee newMember = SquadEmployee.builder()
+            .squadCode(request.getSquadCode())
+            .employeeIdentificationNumber(request.getNewEmployeeId())
+            .projectAndJobId(existsMember.getProjectAndJobId())
+            .isLeader(false)
+            .build();
+
+    squadEmployeeCommandRepository.save(newMember);
   }
 
   private void notifyFPAnalysisFailure(String managerId, String projectId) {

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectEvaluateCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectEvaluateCommandServiceImpl.java
@@ -47,13 +47,11 @@ public class ProjectEvaluateCommandServiceImpl implements ProjectEvaluateCommand
       String complexity = classifyComplexity(req.getFpType(), req.getDet(), req.getFtrOrRet());
       int score = getFpScore(req.getFpType(), complexity);
 
-      // 균등 분배 방식: 스택 수만큼 나눔
       int perStackScore = score / req.getStacks().size();
       for (String stack : req.getStacks()) {
         techStackTotalScoreMap.merge(stack, perStackScore, Integer::sum); // stack이 일치하면 점수 합치기
       }
 
-      // FastAPI에 벡터 저장
       Map<String, Object> payload = new HashMap<>();
       payload.put("function_name", req.getFunctionName());
       payload.put("description", req.getDescription());
@@ -64,7 +62,6 @@ public class ProjectEvaluateCommandServiceImpl implements ProjectEvaluateCommand
       vectorPayloads.add(payload);
     }
 
-    // 기술스택 점수 저장
     for (Map.Entry<String, Integer> entry : techStackTotalScoreMap.entrySet()) {
       String techStackName = entry.getKey();
       int addedScore = entry.getValue();

--- a/src/main/java/com/nexus/sion/feature/project/query/controller/ProjectQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/controller/ProjectQueryController.java
@@ -1,5 +1,9 @@
 package com.nexus.sion.feature.project.query.controller;
 
+import com.nexus.sion.feature.project.query.dto.request.ReplacementRecommendationRequest;
+import com.nexus.sion.feature.project.query.service.ReplacementRecommendationService;
+import com.nexus.sion.feature.squad.query.dto.response.DeveloperSummary;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +17,8 @@ import com.nexus.sion.feature.project.query.service.ProjectQueryService;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("api/v1/projects")
 @RequiredArgsConstructor
@@ -20,6 +26,7 @@ public class ProjectQueryController {
 
   private final ProjectQueryService projectQueryService;
   private final DeveloperProjectWorkQueryService developerProjectWorkQueryService;
+  private final ReplacementRecommendationService replacementRecommendationService;
 
   // 목록 조회
   @PostMapping("/list")
@@ -73,5 +80,17 @@ public class ProjectQueryController {
   public ResponseEntity<ApiResponse<ProjectInfoDto>> getProjectInfo(@PathVariable Long id) {
     ProjectInfoDto response = developerProjectWorkQueryService.getProjectInfo(id);
     return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  // 프로젝트 스쿼드 인원 대체 추천
+  @PostMapping("/replacement")
+  public ResponseEntity<ApiResponse<List<DeveloperSummary>>> recommendReplacement(
+          @RequestBody @Valid ReplacementRecommendationRequest request
+  ) {
+    List<DeveloperSummary> candidates = replacementRecommendationService.recommendCandidates(
+            request.getProjectCode(),
+            request.getLeavingMember()
+    );
+    return ResponseEntity.ok(ApiResponse.success(candidates));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/project/query/dto/request/ReplacementRecommendationRequest.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/dto/request/ReplacementRecommendationRequest.java
@@ -1,0 +1,16 @@
+package com.nexus.sion.feature.project.query.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReplacementRecommendationRequest {
+
+    @NotBlank(message = "프로젝트 코드는 필수입니다.")
+    private String projectCode;
+
+    @NotBlank(message = "대체 대상 사원 ID는 필수입니다.")
+    private String leavingMember;
+}

--- a/src/main/java/com/nexus/sion/feature/project/query/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/dto/response/ProjectDetailResponse.java
@@ -20,10 +20,12 @@ public class ProjectDetailResponse {
   private List<SquadMemberInfo> members;
   private String status;
   private ProjectAnalysisStatus analysisStatus;
+  private String squadCode;
 
   @Getter
   @AllArgsConstructor
   public static class SquadMemberInfo {
+    private String employeeId;
     private Integer isLeader;
     private String imageUrl;
     private String name;

--- a/src/main/java/com/nexus/sion/feature/project/query/repository/ProjectQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/repository/ProjectQueryRepository.java
@@ -160,6 +160,7 @@ public class ProjectQueryRepository {
     // 5. 스쿼드 구성원
     List<ProjectDetailResponse.SquadMemberInfo> members =
         dsl.select(
+                MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
                 SQUAD_EMPLOYEE.IS_LEADER, // ✅ 리더 여부 포함
                 MEMBER.PROFILE_IMAGE_URL,
                 MEMBER.EMPLOYEE_NAME,
@@ -173,12 +174,13 @@ public class ProjectQueryRepository {
                     MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
             .join(PROJECT_AND_JOB)
             .on(SQUAD_EMPLOYEE.PROJECT_AND_JOB_ID.eq(PROJECT_AND_JOB.PROJECT_AND_JOB_ID))
-            .where(SQUAD.PROJECT_CODE.eq(projectCode))
+            .where(SQUAD.PROJECT_CODE.eq(projectCode)).and(SQUAD.IS_ACTIVE.eq((byte)1))
             .orderBy(SQUAD_EMPLOYEE.IS_LEADER.desc()) // 리더 먼저 정렬
             .fetch()
             .map(
                 r ->
                     new ProjectDetailResponse.SquadMemberInfo(
+                            r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER),
                         Integer.valueOf(r.get(SQUAD_EMPLOYEE.IS_LEADER)), // 👈 여기로 포함
                         r.get(MEMBER.PROFILE_IMAGE_URL),
                         r.get(MEMBER.EMPLOYEE_NAME),
@@ -187,6 +189,12 @@ public class ProjectQueryRepository {
     // ✅ 상태 추출 및 반환에 포함
     String status = String.valueOf(project.get(PROJECT.STATUS));
     ProjectAnalysisStatus analysisStatus = project.get(PROJECT.ANALYSIS_STATUS);
+
+    String squadCode = dsl.select(SQUAD.SQUAD_CODE)
+            .from(SQUAD)
+            .where(SQUAD.PROJECT_CODE.eq(projectCode))
+            .and(SQUAD.IS_ACTIVE.eq((byte)1))
+            .fetchOne(SQUAD.SQUAD_CODE);
 
     return new ProjectDetailResponse(
         project.get(PROJECT.TITLE),
@@ -198,7 +206,8 @@ public class ProjectQueryRepository {
         techStacks,
         members,
         status,
-        analysisStatus // ✅ 여기 포함
+        analysisStatus, // ✅ 여기 포함,
+            squadCode
         );
   }
 

--- a/src/main/java/com/nexus/sion/feature/project/query/repository/ReplacementRecommendationRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/repository/ReplacementRecommendationRepository.java
@@ -1,16 +1,13 @@
 package com.nexus.sion.feature.project.query.repository;
 
-import com.example.jooq.generated.enums.MemberGradeCode;
 import com.example.jooq.generated.enums.MemberStatus;
 import com.nexus.sion.feature.squad.query.dto.response.DeveloperSummary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.*;
-import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 import static com.example.jooq.generated.tables.DeveloperTechStack.DEVELOPER_TECH_STACK;
@@ -30,7 +27,6 @@ public class ReplacementRecommendationRepository {
     private final DSLContext dsl;
 
     public List<DeveloperSummary> findCandidatesForReplacement(String projectCode, String employeeId) {
-        // 1. 스쿼드 조회
         Record1<String> squadCodeRecord = dsl
                 .select(SQUAD.SQUAD_CODE)
                 .from(SQUAD)
@@ -38,7 +34,6 @@ public class ReplacementRecommendationRepository {
                 .and(SQUAD.IS_ACTIVE.isTrue())
                 .fetchOne();
 
-        log.info("[1] SquadCodeRecord: {}", squadCodeRecord);
 
         if (squadCodeRecord == null) {
             throw new IllegalArgumentException("활성화된 스쿼드를 찾을 수 없습니다.");
@@ -46,7 +41,6 @@ public class ReplacementRecommendationRepository {
 
         String squadCode = squadCodeRecord.value1();
 
-        // 2. 참여 직무 조회
         Record1<Long> projectAndJobIdRecord = dsl
                 .select(SQUAD_EMPLOYEE.PROJECT_AND_JOB_ID)
                 .from(SQUAD_EMPLOYEE)
@@ -54,7 +48,6 @@ public class ReplacementRecommendationRepository {
                 .and(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER.eq(employeeId))
                 .fetchOne();
 
-        log.info("[2] ProjectAndJobIdRecord: {}", projectAndJobIdRecord);
 
         if (projectAndJobIdRecord == null) {
             throw new IllegalArgumentException("직무를 찾을 수 없습니다.");
@@ -62,14 +55,12 @@ public class ReplacementRecommendationRepository {
 
         Long projectAndJobId = projectAndJobIdRecord.value1();
 
-        // 3. 해당 직무에 필요한 기술스택 조회
         List<String> requiredStacks = dsl
                 .select(JOB_AND_TECH_STACK.TECH_STACK_NAME)
                 .from(JOB_AND_TECH_STACK)
                 .where(JOB_AND_TECH_STACK.PROJECT_AND_JOB_ID.eq(projectAndJobId))
                 .fetchInto(String.class);
 
-        log.info("[3] Required TechStacks: {}", requiredStacks);
 
         if (requiredStacks.isEmpty()) {
             throw new IllegalArgumentException("직무에 필요한 기술스택이 없습니다.");
@@ -81,9 +72,7 @@ public class ReplacementRecommendationRepository {
                 .where(PROJECT.PROJECT_CODE.eq(projectCode))
                 .fetchOne(PROJECT.DOMAIN_NAME);
 
-        log.info("[4] domainName: {}", domainName);
 
-        // 4. 모든 기술스택을 포함하는 후보 개발자 조회용 임시 테이블
         Table<?> requiredTechCount = dsl
                 .select(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER.as("EMPLOYEE_IDENTIFICATION_NUMBER"))
                 .from(DEVELOPER_TECH_STACK)
@@ -92,57 +81,11 @@ public class ReplacementRecommendationRepository {
                 .having(DSL.countDistinct(DEVELOPER_TECH_STACK.TECH_STACK_NAME).eq(requiredStacks.size()))
                 .asTable("required_developers");
 
-        log.info(">> field exists? {}", requiredTechCount.field("EMPLOYEE_IDENTIFICATION_NUMBER", String.class) != null);
-
-
-        List<String> requiredDevs = dsl
-                .select(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER)
-                .from(DEVELOPER_TECH_STACK)
-                .where(DEVELOPER_TECH_STACK.TECH_STACK_NAME.in(requiredStacks))
-                .groupBy(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER)
-                .having(DSL.countDistinct(DEVELOPER_TECH_STACK.TECH_STACK_NAME).eq(requiredStacks.size()))
-                .fetchInto(String.class);
-
-        log.info(">> Required Developer Count: {}", requiredDevs.size());
-        log.info(">> Required Developers: {}", requiredDevs);
-
-
-        Result<? extends Record> records = dsl
-                .select(
-                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
-                        MEMBER.EMPLOYEE_NAME,
-                        MEMBER.GRADE_CODE,
-                        DSL.avg(DEVELOPER_TECH_STACK.TECH_STACK_TOTAL_SCORES),
-                        DSL.coalesce(DSL.countDistinct(
-                                DSL.when(PROJECT.DOMAIN_NAME.eq(domainName), SQUAD_EMPLOYEE.SQUAD_CODE)
-                        ), 0),
-                        GRADE.PRODUCTIVITY,
-                        GRADE.MONTHLY_UNIT_PRICE
-                )
-                .from(MEMBER)
-                .join(GRADE).on(MEMBER.GRADE_CODE.cast(VARCHAR).eq(GRADE.GRADE_CODE.cast(VARCHAR)))
-                .join(DEVELOPER_TECH_STACK).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER))
-                .join(requiredTechCount).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(requiredTechCount.field("EMPLOYEE_IDENTIFICATION_NUMBER", String.class)))
-                .leftJoin(SQUAD_EMPLOYEE).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER))
-                .leftJoin(SQUAD).on(SQUAD_EMPLOYEE.SQUAD_CODE.eq(SQUAD.SQUAD_CODE))
-                .leftJoin(PROJECT).on(SQUAD.PROJECT_CODE.eq(PROJECT.PROJECT_CODE))
-                .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
-                .groupBy(
-                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
-                        MEMBER.EMPLOYEE_NAME,
-                        MEMBER.GRADE_CODE,
-                        GRADE.PRODUCTIVITY,
-                        GRADE.MONTHLY_UNIT_PRICE
-                )
-                .fetch();
-
-        for (var record : records) {
-            log.info(">> Record: {}", record);
-        }
-
 
         // 5. 최종 후보군 상세 정보 조회
-        List<DeveloperSummary> candidates = dsl
+
+
+        return dsl
                 .select(
                         MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.as("id"),
                         MEMBER.EMPLOYEE_NAME.as("name"),
@@ -162,6 +105,11 @@ public class ReplacementRecommendationRepository {
                 .leftJoin(SQUAD).on(SQUAD_EMPLOYEE.SQUAD_CODE.eq(SQUAD.SQUAD_CODE))
                 .leftJoin(PROJECT).on(SQUAD.PROJECT_CODE.eq(PROJECT.PROJECT_CODE))
                 .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+                .and(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.notIn(
+                        dsl.select(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER)
+                                .from(SQUAD_EMPLOYEE)
+                                .where(SQUAD_EMPLOYEE.SQUAD_CODE.eq(squadCode))
+                ))
                 .groupBy(
                         MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
                         MEMBER.EMPLOYEE_NAME,
@@ -178,9 +126,5 @@ public class ReplacementRecommendationRepository {
                         .productivity(record.get(GRADE.PRODUCTIVITY))
                         .monthlyUnitPrice(record.get(GRADE.MONTHLY_UNIT_PRICE))
                         .build());
-
-        log.info("[5] Final Developer Candidates: {}", candidates);
-
-        return candidates;
     }
 }

--- a/src/main/java/com/nexus/sion/feature/project/query/repository/ReplacementRecommendationRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/repository/ReplacementRecommendationRepository.java
@@ -1,0 +1,186 @@
+package com.nexus.sion.feature.project.query.repository;
+
+import com.example.jooq.generated.enums.MemberGradeCode;
+import com.example.jooq.generated.enums.MemberStatus;
+import com.nexus.sion.feature.squad.query.dto.response.DeveloperSummary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.example.jooq.generated.tables.DeveloperTechStack.DEVELOPER_TECH_STACK;
+import static com.example.jooq.generated.tables.JobAndTechStack.JOB_AND_TECH_STACK;
+import static com.example.jooq.generated.tables.Squad.SQUAD;
+import static com.example.jooq.generated.tables.SquadEmployee.SQUAD_EMPLOYEE;
+import static com.example.jooq.generated.tables.Member.MEMBER;
+import static com.example.jooq.generated.tables.Grade.GRADE;
+import static com.example.jooq.generated.tables.Project.PROJECT;
+import static org.jooq.impl.SQLDataType.VARCHAR;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class ReplacementRecommendationRepository {
+
+    private final DSLContext dsl;
+
+    public List<DeveloperSummary> findCandidatesForReplacement(String projectCode, String employeeId) {
+        // 1. 스쿼드 조회
+        Record1<String> squadCodeRecord = dsl
+                .select(SQUAD.SQUAD_CODE)
+                .from(SQUAD)
+                .where(SQUAD.PROJECT_CODE.eq(projectCode))
+                .and(SQUAD.IS_ACTIVE.isTrue())
+                .fetchOne();
+
+        log.info("[1] SquadCodeRecord: {}", squadCodeRecord);
+
+        if (squadCodeRecord == null) {
+            throw new IllegalArgumentException("활성화된 스쿼드를 찾을 수 없습니다.");
+        }
+
+        String squadCode = squadCodeRecord.value1();
+
+        // 2. 참여 직무 조회
+        Record1<Long> projectAndJobIdRecord = dsl
+                .select(SQUAD_EMPLOYEE.PROJECT_AND_JOB_ID)
+                .from(SQUAD_EMPLOYEE)
+                .where(SQUAD_EMPLOYEE.SQUAD_CODE.eq(squadCode))
+                .and(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER.eq(employeeId))
+                .fetchOne();
+
+        log.info("[2] ProjectAndJobIdRecord: {}", projectAndJobIdRecord);
+
+        if (projectAndJobIdRecord == null) {
+            throw new IllegalArgumentException("직무를 찾을 수 없습니다.");
+        }
+
+        Long projectAndJobId = projectAndJobIdRecord.value1();
+
+        // 3. 해당 직무에 필요한 기술스택 조회
+        List<String> requiredStacks = dsl
+                .select(JOB_AND_TECH_STACK.TECH_STACK_NAME)
+                .from(JOB_AND_TECH_STACK)
+                .where(JOB_AND_TECH_STACK.PROJECT_AND_JOB_ID.eq(projectAndJobId))
+                .fetchInto(String.class);
+
+        log.info("[3] Required TechStacks: {}", requiredStacks);
+
+        if (requiredStacks.isEmpty()) {
+            throw new IllegalArgumentException("직무에 필요한 기술스택이 없습니다.");
+        }
+
+        String domainName = dsl
+                .select(PROJECT.DOMAIN_NAME)
+                .from(PROJECT)
+                .where(PROJECT.PROJECT_CODE.eq(projectCode))
+                .fetchOne(PROJECT.DOMAIN_NAME);
+
+        log.info("[4] domainName: {}", domainName);
+
+        // 4. 모든 기술스택을 포함하는 후보 개발자 조회용 임시 테이블
+        Table<?> requiredTechCount = dsl
+                .select(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER.as("EMPLOYEE_IDENTIFICATION_NUMBER"))
+                .from(DEVELOPER_TECH_STACK)
+                .where(DEVELOPER_TECH_STACK.TECH_STACK_NAME.in(requiredStacks))
+                .groupBy(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER)
+                .having(DSL.countDistinct(DEVELOPER_TECH_STACK.TECH_STACK_NAME).eq(requiredStacks.size()))
+                .asTable("required_developers");
+
+        log.info(">> field exists? {}", requiredTechCount.field("EMPLOYEE_IDENTIFICATION_NUMBER", String.class) != null);
+
+
+        List<String> requiredDevs = dsl
+                .select(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER)
+                .from(DEVELOPER_TECH_STACK)
+                .where(DEVELOPER_TECH_STACK.TECH_STACK_NAME.in(requiredStacks))
+                .groupBy(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER)
+                .having(DSL.countDistinct(DEVELOPER_TECH_STACK.TECH_STACK_NAME).eq(requiredStacks.size()))
+                .fetchInto(String.class);
+
+        log.info(">> Required Developer Count: {}", requiredDevs.size());
+        log.info(">> Required Developers: {}", requiredDevs);
+
+
+        Result<? extends Record> records = dsl
+                .select(
+                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                        MEMBER.EMPLOYEE_NAME,
+                        MEMBER.GRADE_CODE,
+                        DSL.avg(DEVELOPER_TECH_STACK.TECH_STACK_TOTAL_SCORES),
+                        DSL.coalesce(DSL.countDistinct(
+                                DSL.when(PROJECT.DOMAIN_NAME.eq(domainName), SQUAD_EMPLOYEE.SQUAD_CODE)
+                        ), 0),
+                        GRADE.PRODUCTIVITY,
+                        GRADE.MONTHLY_UNIT_PRICE
+                )
+                .from(MEMBER)
+                .join(GRADE).on(MEMBER.GRADE_CODE.cast(VARCHAR).eq(GRADE.GRADE_CODE.cast(VARCHAR)))
+                .join(DEVELOPER_TECH_STACK).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .join(requiredTechCount).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(requiredTechCount.field("EMPLOYEE_IDENTIFICATION_NUMBER", String.class)))
+                .leftJoin(SQUAD_EMPLOYEE).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .leftJoin(SQUAD).on(SQUAD_EMPLOYEE.SQUAD_CODE.eq(SQUAD.SQUAD_CODE))
+                .leftJoin(PROJECT).on(SQUAD.PROJECT_CODE.eq(PROJECT.PROJECT_CODE))
+                .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+                .groupBy(
+                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                        MEMBER.EMPLOYEE_NAME,
+                        MEMBER.GRADE_CODE,
+                        GRADE.PRODUCTIVITY,
+                        GRADE.MONTHLY_UNIT_PRICE
+                )
+                .fetch();
+
+        for (var record : records) {
+            log.info(">> Record: {}", record);
+        }
+
+
+        // 5. 최종 후보군 상세 정보 조회
+        List<DeveloperSummary> candidates = dsl
+                .select(
+                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.as("id"),
+                        MEMBER.EMPLOYEE_NAME.as("name"),
+                        MEMBER.GRADE_CODE.as("grade"),
+                        DSL.avg(DEVELOPER_TECH_STACK.TECH_STACK_TOTAL_SCORES).as("avgTechScore"),
+                        DSL.coalesce(DSL.countDistinct(
+                                DSL.when(PROJECT.DOMAIN_NAME.eq(domainName), SQUAD_EMPLOYEE.SQUAD_CODE)
+                        ), 0).as("domainCount"),
+                        GRADE.PRODUCTIVITY,
+                        GRADE.MONTHLY_UNIT_PRICE
+                )
+                .from(MEMBER)
+                .join(GRADE).on(MEMBER.GRADE_CODE.cast(VARCHAR).eq(GRADE.GRADE_CODE.cast(VARCHAR)))
+                .join(DEVELOPER_TECH_STACK).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .join(requiredTechCount).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(requiredTechCount.field("EMPLOYEE_IDENTIFICATION_NUMBER", String.class)))
+                .leftJoin(SQUAD_EMPLOYEE).on(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER.eq(SQUAD_EMPLOYEE.EMPLOYEE_IDENTIFICATION_NUMBER))
+                .leftJoin(SQUAD).on(SQUAD_EMPLOYEE.SQUAD_CODE.eq(SQUAD.SQUAD_CODE))
+                .leftJoin(PROJECT).on(SQUAD.PROJECT_CODE.eq(PROJECT.PROJECT_CODE))
+                .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+                .groupBy(
+                        MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                        MEMBER.EMPLOYEE_NAME,
+                        MEMBER.GRADE_CODE,
+                        GRADE.PRODUCTIVITY,
+                        GRADE.MONTHLY_UNIT_PRICE
+                )
+                .fetch(record -> DeveloperSummary.builder()
+                        .id(record.get("id", String.class))
+                        .name(record.get("name", String.class))
+                        .grade(record.get("grade", String.class))
+                        .avgTechScore(record.get("avgTechScore", Double.class))
+                        .domainCount(record.get("domainCount", Integer.class))
+                        .productivity(record.get(GRADE.PRODUCTIVITY))
+                        .monthlyUnitPrice(record.get(GRADE.MONTHLY_UNIT_PRICE))
+                        .build());
+
+        log.info("[5] Final Developer Candidates: {}", candidates);
+
+        return candidates;
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
@@ -45,12 +45,14 @@ public class DeveloperProjectWorkQueryServiceImpl implements DeveloperProjectWor
 
   @Override
   public ProjectInfoDto getProjectInfo(Long workId) {
-    return projectQueryRepository.findProjectInfoByWorkId(workId);
+    return null;
+//    return projectQueryRepository.findProjectInfoByWorkId(workId);
   }
 
   @Override
   public WorkInfoQueryDto getRequestDetailById(Long projectWorkId) {
-    return projectQueryRepository.findById(projectWorkId);
+    return null;
+//    return projectQueryRepository.findById(projectWorkId);
   }
 
   @Override

--- a/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/DeveloperProjectWorkQueryServiceImpl.java
@@ -45,14 +45,12 @@ public class DeveloperProjectWorkQueryServiceImpl implements DeveloperProjectWor
 
   @Override
   public ProjectInfoDto getProjectInfo(Long workId) {
-    return null;
-//    return projectQueryRepository.findProjectInfoByWorkId(workId);
+    return projectQueryRepository.findProjectInfoByWorkId(workId);
   }
 
   @Override
   public WorkInfoQueryDto getRequestDetailById(Long projectWorkId) {
-    return null;
-//    return projectQueryRepository.findById(projectWorkId);
+    return projectQueryRepository.findById(projectWorkId);
   }
 
   @Override

--- a/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
@@ -60,38 +60,39 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
 
   public PageResponse<ProjectListResponse> getProjectsByEmployeeId(
       String employeeId, List<String> statuses, int page, int size) {
-    List<Project> pojos =
-        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
-    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
-
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-    List<ProjectListResponse> content =
-        pojos.stream()
-            .map(
-                p ->
-                    ProjectListResponse.builder()
-                        .projectCode(p.getProjectCode())
-                        .title(p.getTitle())
-                        .description(p.getDescription())
-                        .startDate(
-                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
-                        .endDate(
-                            p.getExpectedEndDate() != null
-                                ? p.getExpectedEndDate().format(formatter)
-                                : null)
-                        .period(
-                            p.getStartDate() != null && p.getExpectedEndDate() != null
-                                ? (int)
-                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
-                                : 0)
-                        .status(p.getStatus() != null ? p.getStatus().name() : null)
-                        .domainName(p.getDomainName())
-                        .hrCount(p.getNumberOfMembers())
-                        .analysisStatus(p.getAnalysisStatus())
-                        .build())
-            .toList();
-
-    return PageResponse.fromJooq(content, totalCount, page, size);
+//    List<Project> pojos =
+//        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
+//    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
+//
+//    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+//
+//    List<ProjectListResponse> content =
+//        pojos.stream()
+//            .map(
+//                p ->
+//                    ProjectListResponse.builder()
+//                        .projectCode(p.getProjectCode())
+//                        .title(p.getTitle())
+//                        .description(p.getDescription())
+//                        .startDate(
+//                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
+//                        .endDate(
+//                            p.getExpectedEndDate() != null
+//                                ? p.getExpectedEndDate().format(formatter)
+//                                : null)
+//                        .period(
+//                            p.getStartDate() != null && p.getExpectedEndDate() != null
+//                                ? (int)
+//                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
+//                                : 0)
+//                        .status(p.getStatus() != null ? p.getStatus().name() : null)
+//                        .domainName(p.getDomainName())
+//                        .hrCount(p.getNumberOfMembers())
+//                        .analysisStatus(p.getAnalysisStatus())
+//                        .build())
+//            .toList();
+//
+//    return PageResponse.fromJooq(content, totalCount, page, size);
+      return null;
   }
 }

--- a/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/ProjectQueryServiceImpl.java
@@ -60,39 +60,38 @@ public class ProjectQueryServiceImpl implements ProjectQueryService {
 
   public PageResponse<ProjectListResponse> getProjectsByEmployeeId(
       String employeeId, List<String> statuses, int page, int size) {
-//    List<Project> pojos =
-//        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
-//    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
-//
-//    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-//
-//    List<ProjectListResponse> content =
-//        pojos.stream()
-//            .map(
-//                p ->
-//                    ProjectListResponse.builder()
-//                        .projectCode(p.getProjectCode())
-//                        .title(p.getTitle())
-//                        .description(p.getDescription())
-//                        .startDate(
-//                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
-//                        .endDate(
-//                            p.getExpectedEndDate() != null
-//                                ? p.getExpectedEndDate().format(formatter)
-//                                : null)
-//                        .period(
-//                            p.getStartDate() != null && p.getExpectedEndDate() != null
-//                                ? (int)
-//                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
-//                                : 0)
-//                        .status(p.getStatus() != null ? p.getStatus().name() : null)
-//                        .domainName(p.getDomainName())
-//                        .hrCount(p.getNumberOfMembers())
-//                        .analysisStatus(p.getAnalysisStatus())
-//                        .build())
-//            .toList();
-//
-//    return PageResponse.fromJooq(content, totalCount, page, size);
-      return null;
+    List<Project> pojos =
+        projectQueryRepository.findProjectsByEmployeeId(employeeId, statuses, page, size);
+    long totalCount = projectQueryRepository.countProjectsByEmployeeId(employeeId, statuses);
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    List<ProjectListResponse> content =
+        pojos.stream()
+            .map(
+                p ->
+                    ProjectListResponse.builder()
+                        .projectCode(p.getProjectCode())
+                        .title(p.getTitle())
+                        .description(p.getDescription())
+                        .startDate(
+                            p.getStartDate() != null ? p.getStartDate().format(formatter) : null)
+                        .endDate(
+                            p.getExpectedEndDate() != null
+                                ? p.getExpectedEndDate().format(formatter)
+                                : null)
+                        .period(
+                            p.getStartDate() != null && p.getExpectedEndDate() != null
+                                ? (int)
+                                    p.getStartDate().until(p.getExpectedEndDate()).toTotalMonths()
+                                : 0)
+                        .status(p.getStatus() != null ? p.getStatus().name() : null)
+                        .domainName(p.getDomainName())
+                        .hrCount(p.getNumberOfMembers())
+                        .analysisStatus(p.getAnalysisStatus())
+                        .build())
+            .toList();
+
+    return PageResponse.fromJooq(content, totalCount, page, size);
   }
 }

--- a/src/main/java/com/nexus/sion/feature/project/query/service/ReplacementRecommendationService.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/ReplacementRecommendationService.java
@@ -1,0 +1,9 @@
+package com.nexus.sion.feature.project.query.service;
+
+import com.nexus.sion.feature.squad.query.dto.response.DeveloperSummary;
+
+import java.util.List;
+
+public interface ReplacementRecommendationService {
+    List<DeveloperSummary> recommendCandidates(String projectCode, String employeeId);
+}

--- a/src/main/java/com/nexus/sion/feature/project/query/service/ReplacementRecommendationServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/query/service/ReplacementRecommendationServiceImpl.java
@@ -1,0 +1,31 @@
+package com.nexus.sion.feature.project.query.service;
+
+import com.nexus.sion.feature.project.query.repository.ReplacementRecommendationRepository;
+import com.nexus.sion.feature.squad.query.dto.response.DeveloperSummary;
+import com.nexus.sion.feature.squad.query.util.CalculateSquad;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ReplacementRecommendationServiceImpl implements ReplacementRecommendationService {
+
+    private final ReplacementRecommendationRepository recommendationRepository;
+    private final CalculateSquad calculateSquad;
+
+    @Override
+    public List<DeveloperSummary> recommendCandidates(String projectCode, String employeeId) {
+        List<DeveloperSummary> rawCandidates =
+                recommendationRepository.findCandidatesForReplacement(projectCode, employeeId);
+
+        calculateSquad.applyWeightToCandidates(rawCandidates);
+
+        return rawCandidates.stream()
+                .sorted(Comparator.comparingDouble(DeveloperSummary::getWeight).reversed())
+                .limit(5)
+                .toList();
+    }
+}

--- a/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/application/service/SquadCommandServiceImpl.java
@@ -92,7 +92,6 @@ public class SquadCommandServiceImpl implements SquadCommandService {
                         .employeeIdentificationNumber(dev.getEmployeeId())
                         .projectAndJobId(dev.getProjectAndJobId())
                         .isLeader(dev.getIsLeader())
-                        .assignedDate(LocalDate.now())
                         .build())
             .toList();
 

--- a/src/main/java/com/nexus/sion/feature/squad/command/domain/aggregate/entity/SquadEmployee.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/domain/aggregate/entity/SquadEmployee.java
@@ -15,14 +15,13 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class SquadEmployee extends BaseTimeEntity {
-  // base entity : 생성일자, 수정일자 자동생성 및 업데이트 설정
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "squad_employee_id")
   private Long id;
 
-  @Column(name = "assigned_date", nullable = false)
+  @Column(name = "assigned_date")
   private LocalDate assignedDate;
 
   @Column(name = "employee_identification_number", nullable = false, length = 30)

--- a/src/main/java/com/nexus/sion/feature/squad/command/repository/SquadEmployeeCommandRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/repository/SquadEmployeeCommandRepository.java
@@ -1,7 +1,9 @@
 package com.nexus.sion.feature.squad.command.repository;
 
 import java.util.List;
+import java.util.Optional;
 
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,10 @@ public interface SquadEmployeeCommandRepository extends JpaRepository<SquadEmplo
     WHERE pj.projectCode = :projectCode
 """)
   List<SquadEmployee> findByProjectCode(@Param("projectCode") String projectCode);
+
+  void deleteBySquadCodeAndEmployeeIdentificationNumber(String squadCode, String oldEmployeeId);
+
+  boolean existsBySquadCodeAndEmployeeIdentificationNumber(String squadCode, String oldEmployeeId);
+
+  Optional<SquadEmployee> findBySquadCodeAndEmployeeIdentificationNumber(String squadCode,  String oldEmployeeId);
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
@@ -29,6 +29,7 @@ public class SquadDetailResponse {
   private String description;
   private SquadOriginType origin;
   private Boolean isActive;
+  private String projectCode;
 
   @Getter
   @Builder

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -205,6 +205,7 @@ public class SquadQueryRepository {
         .isActive(isActive)
         .description(squad.get(SQUAD.DESCRIPTION))
         .origin(squad.get(SQUAD.ORIGIN_TYPE))
+        .projectCode(squad.get(SQUAD.PROJECT_CODE))
         .build();
   }
 }

--- a/src/main/java/com/nexus/sion/feature/techstack/command/domain/aggregate/TechStack.java
+++ b/src/main/java/com/nexus/sion/feature/techstack/command/domain/aggregate/TechStack.java
@@ -4,16 +4,15 @@ import jakarta.persistence.*;
 
 import com.nexus.sion.common.domain.BaseTimeEntity;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Table(name = "tech_stack")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
+@Builder
+@AllArgsConstructor
 public class TechStack extends BaseTimeEntity {
   // base entity : 생성일자, 수정일자 자동생성 및 업데이트 설정
   @Id

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,4 +94,5 @@ management:
 ai:
   fp-infer: http://localhost:8100/fp-infer
   embed-function: http://localhost:8100/fp-embed
+  fp-freelencer-infer: http://localhost:8100/fp-freelancer-infer
 


### PR DESCRIPTION
## 🪐 작업 내용
- 특정 프로젝트의 대체 대상 사원 ID를 기반으로 적합한 후보군을 추천하는 로직을 구현했습니다. 
- 기존 직무 기준 후보자를 추천하는 로직을 재사용하여 프로젝트에서 직무에서 사용하는 기술 스택 점수와 도메일 사용 횟수를 기준으로 1등부터 5등까지를 추천하는 것으로 구현했습니다. 


<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [ ]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [ ]  spotless apply 적용 여부
      `./gradlew spotlessApply`
