### PR TITLE
[Feat] 관리자 메인 대시보드 조회 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/controller/MemberQueryController.java
@@ -2,6 +2,7 @@ package com.nexus.sion.feature.member.query.controller;
 
 import java.util.List;
 
+import com.nexus.sion.feature.member.query.dto.response.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,10 +15,6 @@ import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.member.query.dto.internal.MemberListQuery;
 import com.nexus.sion.feature.member.query.dto.request.MemberListRequest;
 import com.nexus.sion.feature.member.query.dto.request.MemberSquadSearchRequest;
-import com.nexus.sion.feature.member.query.dto.response.AdminSearchResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberDetailResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberListResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberSquadListResponse;
 import com.nexus.sion.feature.member.query.service.MemberQueryService;
 
 import lombok.RequiredArgsConstructor;
@@ -116,4 +113,10 @@ public class MemberQueryController {
     PageResponse<MemberSquadListResponse> result = memberQueryService.squadSearchMembers(query);
     return ResponseEntity.ok(ApiResponse.success(result));
   }
+
+  @GetMapping("/dashboard-summary")
+  public ResponseEntity<ApiResponse<DashboardSummaryResponse>> getDashboardSummary() {
+    return ResponseEntity.ok(ApiResponse.success(memberQueryService.getDashboardSummary()));
+  }
+
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
@@ -1,0 +1,69 @@
+package com.nexus.sion.feature.member.query.dto.response;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record DashboardSummaryResponse(
+        List<PendingProject> pendingProjects,
+        List<AnalyzingProject> analyzingProjects,
+        List<TopDeveloper> topDevelopers,
+        List<FreelancerSummary> freelancerTop5,
+        DeveloperAvailability developerAvailability,
+        List<TechStackDemand> techStackDemand
+) {
+    @Builder
+    public record PendingProject(
+            String projectCode,
+            String title,
+            String description,
+            Map<String, Integer> roles, // ex) {"백엔드": 2, "프론트엔드": 1}
+            Long budget,
+            String domainName,
+            LocalDate startDate
+    ) {}
+
+    public record AnalyzingProject(
+            String id,
+            String name,
+            LocalDate analysisStartTime
+    ) {}
+
+    @Builder
+    public record TopDeveloper(
+            String id,
+            String name,
+            String grade,
+            BigDecimal productivity,
+            List<String> techStacks,
+            String profileUrl
+    ) {}
+
+    public record FreelancerSummary(
+            String id,
+            String name,
+            int career_years,
+            String grade,
+            String profileUrl
+    ) {}
+
+    public record DeveloperAvailability(
+            int totalAvailable,
+            List<GradeDistribution> gradeDistribution,
+            List<String> availableStacks
+    ) {
+        public record GradeDistribution(
+                String grade,
+                int count
+        ) {}
+    }
+
+    public record TechStackDemand(
+            String name,
+            int count
+    ) {}
+}

--- a/src/main/java/com/nexus/sion/feature/member/query/repository/MemberQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/repository/MemberQueryRepository.java
@@ -1,24 +1,29 @@
 package com.nexus.sion.feature.member.query.repository;
 
-import static com.example.jooq.generated.Tables.GRADE;
+import static com.example.jooq.generated.Tables.*;
 import static com.example.jooq.generated.tables.DeveloperTechStack.DEVELOPER_TECH_STACK;
 import static com.example.jooq.generated.tables.Member.MEMBER;
 import static org.jooq.impl.DSL.*;
 import static org.jooq.impl.SQLDataType.VARCHAR;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import com.example.jooq.generated.enums.MemberStatus;
+import com.example.jooq.generated.enums.ProjectAnalysisStatus;
+import com.example.jooq.generated.enums.ProjectStatus;
+import com.example.jooq.generated.tables.Domain;
+import com.nexus.sion.feature.member.query.dto.response.*;
 import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 
 import com.example.jooq.generated.enums.MemberRole;
 import com.nexus.sion.feature.member.query.dto.internal.MemberListQuery;
 import com.nexus.sion.feature.member.query.dto.request.MemberListRequest;
-import com.nexus.sion.feature.member.query.dto.response.AdminSearchResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberDetailResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberListResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberSquadListResponse;
 import com.nexus.sion.feature.member.query.util.TopTechStackSubqueryProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -29,6 +34,199 @@ public class MemberQueryRepository {
 
   private final DSLContext dsl;
   private final TopTechStackSubqueryProvider topTechStackSubqueryProvider;
+
+  public List<DashboardSummaryResponse.PendingProject> findPendingProjects() {
+    // 하위 쿼리: PENDING 프로젝트 5개만 추출
+    var projects = dsl.select(
+                    PROJECT.PROJECT_CODE,
+                    PROJECT.TITLE,
+                    PROJECT.DESCRIPTION,
+                    PROJECT.BUDGET,
+                    DOMAIN.NAME,
+                    PROJECT.START_DATE
+            )
+            .from(PROJECT)
+            .join(DOMAIN).on(PROJECT.DOMAIN_NAME.eq(Domain.DOMAIN.NAME))
+            .where(PROJECT.STATUS.eq(ProjectStatus.WAITING))  // enum
+            .orderBy(PROJECT.START_DATE.asc()) // 시작일 임박 기준
+            .limit(5)
+            .fetch();
+
+    // 프로젝트 코드별 직무 역할 수 조회 (project_and_job 기준)
+    Map<String, Map<String, Integer>> rolesMap = dsl.select(
+                    PROJECT_AND_JOB.PROJECT_CODE,
+                    PROJECT_AND_JOB.JOB_NAME,
+                    PROJECT_AND_JOB.REQUIRED_NUMBER
+            )
+            .from(PROJECT_AND_JOB)
+            .where(PROJECT_AND_JOB.PROJECT_CODE.in(projects.stream()
+                    .map(p -> p.get(PROJECT.PROJECT_CODE))
+                    .toList()))
+            .fetchGroups(
+                    r -> r.get(PROJECT_AND_JOB.PROJECT_CODE),
+                    r -> Map.entry(r.get(PROJECT_AND_JOB.JOB_NAME), r.get(PROJECT_AND_JOB.REQUIRED_NUMBER))
+            ).entrySet().stream()
+            .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().stream()
+                            .collect(Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    Map.Entry::getValue,
+                                    Integer::sum
+                            ))
+            ));
+
+    return projects.stream()
+            .map(p -> DashboardSummaryResponse.PendingProject.builder()
+                    .projectCode(p.get(PROJECT.PROJECT_CODE))
+                    .title(p.get(PROJECT.TITLE))
+                    .description(p.get(PROJECT.DESCRIPTION))
+                    .budget(p.get(PROJECT.BUDGET))
+                    .domainName(p.get(DOMAIN.NAME))
+                    .startDate(p.get(PROJECT.START_DATE))
+                    .roles(rolesMap.getOrDefault(p.get(PROJECT.PROJECT_CODE), Map.of()))
+                    .build())
+            .toList();
+  }
+  public List<DashboardSummaryResponse.AnalyzingProject> findAnalyzingProjects() {
+    return dsl.select(
+                    PROJECT.PROJECT_CODE,
+                    PROJECT.TITLE,
+                    PROJECT.CREATED_AT
+            )
+            .from(PROJECT)
+            .where(PROJECT.ANALYSIS_STATUS.eq(ProjectAnalysisStatus.PROCEEDING))
+            .orderBy(PROJECT.CREATED_AT.desc())
+            .limit(5)
+            .fetch()
+            .map(r -> new DashboardSummaryResponse.AnalyzingProject(
+                    r.get(PROJECT.PROJECT_CODE),
+                    r.get(PROJECT.TITLE),
+                    r.get(PROJECT.CREATED_AT).toLocalDate()
+            ));
+  }
+  public List<DashboardSummaryResponse.TopDeveloper> fetchTopDevelopers() {
+    // 상위 생산성 개발자 10명 조회
+    var topDevelopers = dsl.select(
+                    MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                    MEMBER.EMPLOYEE_NAME,
+                    MEMBER.GRADE_CODE,
+                    GRADE.PRODUCTIVITY,
+                    MEMBER.PROFILE_IMAGE_URL
+            )
+            .from(MEMBER)
+            .join(GRADE)
+            .on(MEMBER.GRADE_CODE.cast(String.class).eq(GRADE.GRADE_CODE.cast(String.class)))
+            .orderBy(GRADE.PRODUCTIVITY.desc())
+            .limit(10)
+            .fetch();
+
+    // 개발자 ID 리스트
+    List<String> developerIds = topDevelopers.stream()
+            .map(r -> r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+            .toList();
+
+    // 기술스택 조회
+    Map<String, List<String>> techStackMap = dsl.select(
+                    DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER,
+                    DEVELOPER_TECH_STACK.TECH_STACK_NAME
+            )
+            .from(DEVELOPER_TECH_STACK)
+            .where(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER.in(developerIds))
+            .fetchGroups(
+                    r -> r.get(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER),
+                    r -> r.get(DEVELOPER_TECH_STACK.TECH_STACK_NAME)
+            );
+
+    // DTO 변환
+    return topDevelopers.stream()
+            .map(r -> DashboardSummaryResponse.TopDeveloper.builder()
+                    .id(r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+                    .name(r.get(MEMBER.EMPLOYEE_NAME))
+                    .grade(r.get(MEMBER.GRADE_CODE).name())
+                    .productivity(r.get(GRADE.PRODUCTIVITY))
+                    .profileUrl(r.get(MEMBER.PROFILE_IMAGE_URL))
+                    .techStacks(techStackMap.getOrDefault(r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER), List.of()))
+                    .build())
+            .toList();
+  }
+
+  public List<DashboardSummaryResponse.FreelancerSummary> fetchTopFreelancers() {
+    return dsl.select(
+                    MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
+                    MEMBER.EMPLOYEE_NAME,
+                    MEMBER.CAREER_YEARS,
+                    MEMBER.PROFILE_IMAGE_URL,
+                    MEMBER.GRADE_CODE
+            )
+            .from(MEMBER)
+            .where(MEMBER.ROLE.eq(MemberRole.OUTSIDER))
+            .orderBy(MEMBER.CAREER_YEARS.desc(), MEMBER.CREATED_AT.desc())
+            .limit(5)
+            .fetch()
+            .map(r -> new DashboardSummaryResponse.FreelancerSummary(
+                    r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER),
+                    r.get(MEMBER.EMPLOYEE_NAME),
+                    Optional.ofNullable(r.get(MEMBER.CAREER_YEARS)).orElse(0),
+                    r.get(MEMBER.GRADE_CODE) != null ? r.get(MEMBER.GRADE_CODE).name() : "미정",
+                    r.get(MEMBER.PROFILE_IMAGE_URL)
+            ));
+  }
+
+  public DashboardSummaryResponse.DeveloperAvailability fetchDeveloperAvailability() {
+    // 1. 전체 가용 인원 수
+    Integer totalAvailable = dsl.selectCount()
+            .from(MEMBER)
+            .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+            .fetchOne(0, int.class);
+
+    // 2. 등급별 인원 분포
+    List<DashboardSummaryResponse.DeveloperAvailability.GradeDistribution> gradeDistribution =
+            dsl.select(
+                            MEMBER.GRADE_CODE,
+                            DSL.count()
+                    )
+                    .from(MEMBER)
+                    .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+                    .groupBy(MEMBER.GRADE_CODE)
+                    .fetch()
+                    .map(r -> new DashboardSummaryResponse.DeveloperAvailability.GradeDistribution(
+                            r.get(MEMBER.GRADE_CODE) != null ? r.get(MEMBER.GRADE_CODE).name() : "미정",
+                            r.get(DSL.count())
+                    ));
+
+    // 3. available 상태 개발자들의 기술스택 목록 (중복 제거)
+    List<String> availableStacks = dsl.selectDistinct(DEVELOPER_TECH_STACK.TECH_STACK_NAME)
+            .from(DEVELOPER_TECH_STACK)
+            .join(MEMBER)
+            .on(DEVELOPER_TECH_STACK.EMPLOYEE_IDENTIFICATION_NUMBER.eq(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
+            .where(MEMBER.STATUS.eq(MemberStatus.AVAILABLE))
+            .fetch(DEVELOPER_TECH_STACK.TECH_STACK_NAME);
+
+    return new DashboardSummaryResponse.DeveloperAvailability(
+            totalAvailable != null ? totalAvailable : 0,
+            gradeDistribution,
+            availableStacks
+    );
+  }
+
+  public List<DashboardSummaryResponse.TechStackDemand> fetchTopTechStacks() {
+    return dsl.select(
+                    JOB_AND_TECH_STACK.TECH_STACK_NAME,
+                    DSL.countDistinct(PROJECT_AND_JOB.PROJECT_CODE).as("project_count")
+            )
+            .from(JOB_AND_TECH_STACK)
+            .join(PROJECT_AND_JOB)
+            .on(JOB_AND_TECH_STACK.PROJECT_AND_JOB_ID.eq(PROJECT_AND_JOB.PROJECT_AND_JOB_ID))
+            .groupBy(JOB_AND_TECH_STACK.TECH_STACK_NAME)
+            .orderBy(DSL.countDistinct(PROJECT_AND_JOB.PROJECT_CODE).desc())
+            .limit(10)
+            .fetch()
+            .map(r -> new DashboardSummaryResponse.TechStackDemand(
+                    r.get(JOB_AND_TECH_STACK.TECH_STACK_NAME),
+                    r.get("project_count", Integer.class)
+            ));
+  }
 
   public long countMembers(Condition condition) {
     Long count = dsl.selectCount().from(MEMBER).where(condition).fetchOneInto(Long.class);

--- a/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryService.java
@@ -3,10 +3,7 @@ package com.nexus.sion.feature.member.query.service;
 import com.nexus.sion.common.dto.PageResponse;
 import com.nexus.sion.feature.member.query.dto.internal.MemberListQuery;
 import com.nexus.sion.feature.member.query.dto.request.MemberListRequest;
-import com.nexus.sion.feature.member.query.dto.response.AdminSearchResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberDetailResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberListResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberSquadListResponse;
+import com.nexus.sion.feature.member.query.dto.response.*;
 
 public interface MemberQueryService {
   PageResponse<MemberListResponse> getAllMembers(MemberListRequest request);
@@ -18,4 +15,6 @@ public interface MemberQueryService {
   MemberDetailResponse getMemberDetail(String employeeId);
 
   PageResponse<MemberSquadListResponse> squadSearchMembers(MemberListQuery request);
+
+  DashboardSummaryResponse getDashboardSummary();
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryServiceImpl.java
@@ -4,6 +4,7 @@ import static com.example.jooq.generated.tables.Member.MEMBER;
 
 import java.util.List;
 
+import com.nexus.sion.feature.member.query.dto.response.*;
 import org.jooq.Condition;
 import org.jooq.SortField;
 import org.springframework.stereotype.Service;
@@ -17,10 +18,6 @@ import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.member.query.dto.internal.MemberListQuery;
 import com.nexus.sion.feature.member.query.dto.request.MemberListRequest;
-import com.nexus.sion.feature.member.query.dto.response.AdminSearchResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberDetailResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberListResponse;
-import com.nexus.sion.feature.member.query.dto.response.MemberSquadListResponse;
 import com.nexus.sion.feature.member.query.repository.MemberQueryRepository;
 import com.nexus.sion.feature.member.query.util.MemberConditionBuilder;
 import com.nexus.sion.feature.member.query.util.SortFieldSelector;
@@ -132,5 +129,17 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         memberQueryRepository.findAllSquadMembers(query, condition, sortField);
 
     return PageResponse.fromJooq(content, total, query.page(), query.size());
+  }
+
+  @Override
+  public DashboardSummaryResponse getDashboardSummary() {
+    return new DashboardSummaryResponse(
+            memberQueryRepository.findPendingProjects(),
+            memberQueryRepository.findAnalyzingProjects(),
+            memberQueryRepository.fetchTopDevelopers(),
+            memberQueryRepository.fetchTopFreelancers(),
+            memberQueryRepository.fetchDeveloperAvailability(),
+            memberQueryRepository.fetchTopTechStacks()
+    );
   }
 }


### PR DESCRIPTION
## 🪐 작업 내용
- 관리자 메인 대시보드 정보 요약 조회 기능을 구현했습니다. 

<br>

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [o]  기능 구현
- [x]  service mock 단위 테스트
- [x]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
