### PR TITLE
[Feat] 프로젝트 이력 및 이력서 점수 산정 로직 연결

### DIFF
--- a/src/main/java/com/nexus/sion/common/s3/service/DocumentS3Service.java
+++ b/src/main/java/com/nexus/sion/common/s3/service/DocumentS3Service.java
@@ -90,18 +90,16 @@ public class DocumentS3Service {
       if (!"application/pdf".equalsIgnoreCase(contentType)) {
         throw new IllegalArgumentException("PDF 파일만 다운로드할 수 있습니다.");
       }
-
-      InputStream inputStream = connection.getInputStream();
-
+      
       File tempFile = Files.createTempFile("resume_", ".pdf").toFile();
-      try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+      try (InputStream inputStream = connection.getInputStream();
+           FileOutputStream outputStream = new FileOutputStream(tempFile)) {
         byte[] buffer = new byte[8192];
         int bytesRead;
         while ((bytesRead = inputStream.read(buffer)) != -1) {
           outputStream.write(buffer, 0, bytesRead);
         }
       }
-      inputStream.close();
 
       return tempFile;
     } catch (IOException e) {

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
@@ -18,8 +18,8 @@ public class FreelancerCommandController {
 
   @PostMapping("/{freelancerId}/register")
   public ResponseEntity<ApiResponse<Void>> registerAsMember(
-      @PathVariable String freelancerId, @RequestParam("file") MultipartFile multipartFile) {
-    freelancerCommandService.registerFreelancerAsMember(freelancerId, multipartFile);
+      @PathVariable String freelancerId) {
+    freelancerCommandService.registerFreelancerAsMember(freelancerId);
     return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
@@ -1,7 +1,6 @@
 package com.nexus.sion.feature.member.command.application.service;
 
-import org.springframework.web.multipart.MultipartFile;
 
 public interface FreelancerCommandService {
-  void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile);
+  void registerFreelancerAsMember(String freelancerId);
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.nexus.sion.common.s3.service.DocumentS3Service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +35,8 @@ import com.nexus.sion.feature.techstack.command.repository.TechStackRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.swing.text.Document;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -50,64 +53,58 @@ public class FreelancerCommandServiceImpl implements FreelancerCommandService {
   private final MemberScoreHistoryRepository memberScoreHistoryRepository;
   private final FastApiClient fastApiClient;
   private final TechStackRepository techStackRepository;
+  private final DocumentS3Service documentS3Service;
 
   @Override
-  public void registerFreelancerAsMember(String freelancerId, MultipartFile multipartFile) {
+  public void registerFreelancerAsMember(String freelancerId) {
     FreelancerDetailResponse freelancer =
-        freelancerQueryRepository.getFreelancerDetail(freelancerId);
+            freelancerQueryRepository.getFreelancerDetail(freelancerId);
 
     String rawPassword =
-        (freelancer.birthday() != null)
-            ? String.format(
-                "%02d%02d%02d",
-                freelancer.birthday().getYear() % 100,
-                freelancer.birthday().getMonthValue(),
-                freelancer.birthday().getDayOfMonth())
-            : "000000";
+            (freelancer.birthday() != null)
+                    ? String.format(
+                    "%02d%02d%02d",
+                    freelancer.birthday().getYear() % 100,
+                    freelancer.birthday().getMonthValue(),
+                    freelancer.birthday().getDayOfMonth())
+                    : "000000";
 
     String encodedPassword = passwordEncoder.encode(rawPassword);
 
     Member member =
-        memberRepository
-            .findById(freelancer.freelancerId())
-            .orElseGet(
-                () -> {
-                  Member newMember =
-                      Member.builder()
-                          .employeeIdentificationNumber(freelancer.freelancerId())
-                          .employeeName(freelancer.name())
-                          .password(encodedPassword)
-                          .profileImageUrl(
-                              freelancer.profileImageUrl() != null
-                                  ? freelancer.profileImageUrl()
-                                  : "https://api.dicebear.com/9.x/notionists/svg?seed="
-                                      + freelancer.freelancerId())
-                          .phoneNumber(freelancer.phoneNumber())
-                          .email(freelancer.email())
-                          .birthday(freelancer.birthday())
-                          .careerYears(freelancer.careerYears())
-                          .joinedAt(LocalDate.now())
-                          .role(MemberRole.OUTSIDER)
-                          .status(MemberStatus.AVAILABLE)
-                          .build();
-                  return memberRepository.save(newMember);
-                });
+            memberRepository
+                    .findById(freelancer.freelancerId())
+                    .orElseGet(
+                            () -> {
+                              Member newMember =
+                                      Member.builder()
+                                              .employeeIdentificationNumber(freelancer.freelancerId())
+                                              .employeeName(freelancer.name())
+                                              .password(encodedPassword)
+                                              .profileImageUrl(
+                                                      freelancer.profileImageUrl() != null
+                                                              ? freelancer.profileImageUrl()
+                                                              : "https://api.dicebear.com/9.x/notionists/svg?seed="
+                                                              + freelancer.freelancerId())
+                                              .phoneNumber(freelancer.phoneNumber())
+                                              .email(freelancer.email())
+                                              .birthday(freelancer.birthday())
+                                              .careerYears(freelancer.careerYears())
+                                              .joinedAt(LocalDate.now())
+                                              .role(MemberRole.OUTSIDER)
+                                              .status(MemberStatus.AVAILABLE)
+                                              .build();
+                              return memberRepository.save(newMember);
+                            });
 
     memberRepository.save(member);
 
     File tempFile;
     List<FunctionScore> functions;
-    try {
-      tempFile = File.createTempFile("input_", ".pdf");
-      multipartFile.transferTo(tempFile);
-
+      tempFile = documentS3Service.downloadFileFromUrl(freelancer.resumeUrl());
       functions = fastApiClient.requestFpFreelencerInference(tempFile);
-    } catch (IOException e) {
-      log.error("[FP 분석 실패] {}", e.getMessage(), e);
-      throw new BusinessException(ErrorCode.FP_ANALYZE_FAIL);
-    }
 
-    // FastAPI 분석 결과로 기술스택 점수 누적 계산
+      // FastAPI 분석 결과로 기술스택 점수 누적 계산
     Map<String, Integer> techStackTotalScoreMap = new HashMap<>();
     for (FunctionScore req : functions) {
       String complexity = classifyComplexity(req.getFpType(), req.getDet(), req.getFtrOrRet());
@@ -124,30 +121,30 @@ public class FreelancerCommandServiceImpl implements FreelancerCommandService {
       int addedScore = entry.getValue();
 
       techStackRepository
-          .findById(techStackName)
-          .orElseGet(
-              () ->
-                  techStackRepository.save(
-                      TechStack.builder().techStackName(techStackName).build()));
+              .findById(techStackName)
+              .orElseGet(
+                      () ->
+                              techStackRepository.save(
+                                      TechStack.builder().techStackName(techStackName).build()));
 
       DeveloperTechStack stack =
-          developerTechStackRepository
-              .findByEmployeeIdentificationNumberAndTechStackName(
-                  freelancer.freelancerId(), techStackName)
-              .orElseGet(
-                  () ->
-                      developerTechStackRepository.save(
-                          DeveloperTechStack.builder()
-                              .employeeIdentificationNumber(freelancer.freelancerId())
-                              .techStackName(techStackName)
-                              .totalScore(0)
-                              .build()));
+              developerTechStackRepository
+                      .findByEmployeeIdentificationNumberAndTechStackName(
+                              freelancer.freelancerId(), techStackName)
+                      .orElseGet(
+                              () ->
+                                      developerTechStackRepository.save(
+                                              DeveloperTechStack.builder()
+                                                      .employeeIdentificationNumber(freelancer.freelancerId())
+                                                      .techStackName(techStackName)
+                                                      .totalScore(0)
+                                                      .build()));
 
       developerTechStackHistoryRepository.save(
-          DeveloperTechStackHistory.builder()
-              .addedScore(addedScore)
-              .developerTechStackId(stack.getId())
-              .build());
+              DeveloperTechStackHistory.builder()
+                      .addedScore(addedScore)
+                      .developerTechStackId(stack.getId())
+                      .build());
 
       stack.setTotalScore(stack.getTotalScore() + addedScore);
       developerTechStackRepository.save(stack);
@@ -155,25 +152,26 @@ public class FreelancerCommandServiceImpl implements FreelancerCommandService {
 
     // Member 점수 이력 갱신
     int totalStackScore =
-        developerTechStackRepository
-            .findAllByEmployeeIdentificationNumber(freelancer.freelancerId())
-            .stream()
-            .mapToInt(DeveloperTechStack::getTotalScore)
-            .sum();
+            developerTechStackRepository
+                    .findAllByEmployeeIdentificationNumber(freelancer.freelancerId())
+                    .stream()
+                    .mapToInt(DeveloperTechStack::getTotalScore)
+                    .sum();
 
     MemberScoreHistory scoreHistory =
-        memberScoreHistoryRepository
-            .findByEmployeeIdentificationNumber(freelancer.freelancerId())
-            .orElseGet(
-                () ->
-                    MemberScoreHistory.builder()
-                        .employeeIdentificationNumber(freelancer.freelancerId())
-                        .totalCertificateScores(0)
-                        .totalTechStackScores(0)
-                        .build());
+            memberScoreHistoryRepository
+                    .findByEmployeeIdentificationNumber(freelancer.freelancerId())
+                    .orElseGet(
+                            () ->
+                                    MemberScoreHistory.builder()
+                                            .employeeIdentificationNumber(freelancer.freelancerId())
+                                            .totalCertificateScores(0)
+                                            .totalTechStackScores(0)
+                                            .build());
     scoreHistory.setTotalTechStackScores(totalStackScore);
     memberScoreHistoryRepository.save(scoreHistory);
 
     freelancerRepository.deleteById(freelancer.freelancerId());
   }
+
 }

--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
@@ -37,7 +37,7 @@ public record DashboardSummaryResponse(
       String profileUrl) {}
 
   public record FreelancerSummary(
-      String id, String name, int career_years, String grade, String profileUrl) {}
+      String id, String name, int careerYears, String grade, String profileUrl) {}
 
   public record DeveloperAvailability(
       int totalAvailable, List<GradeDistribution> gradeDistribution, List<String> availableStacks) {

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkCommandServiceImpl.java
@@ -58,7 +58,7 @@ public class DeveloperProjectWorkCommandServiceImpl implements DeveloperProjectW
 
     List<DeveloperProjectWorkHistoryTechStack> techStacks = workHistoryTechStackRepository.findAllByDeveloperProjectWorkHistoryIdIn(historyIds);
 
-    Map<Long, List<String>> historyIdToStacksMap = techStacks.stream()
+    Map<Long, List<String>> historyIdToStackNamesMap = techStacks.stream()
             .collect(Collectors.groupingBy(
                     DeveloperProjectWorkHistoryTechStack::getDeveloperProjectWorkHistoryId,
                     Collectors.mapping(DeveloperProjectWorkHistoryTechStack::getTechStackName, Collectors.toList())
@@ -71,7 +71,7 @@ public class DeveloperProjectWorkCommandServiceImpl implements DeveloperProjectW
                     history.getFunctionType().name(),
                     history.getDet(),
                     history.getFtr(),
-                    historyIdToStacksMap.getOrDefault(history.getId(), List.of())
+                    historyIdToStackNamesMap.getOrDefault(history.getId(), List.of())
             ))
             .toList();
 

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/DeveloperProjectWorkCommandServiceImpl.java
@@ -1,7 +1,12 @@
 package com.nexus.sion.feature.project.command.application.service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.nexus.sion.feature.project.command.application.dto.FunctionScore;
+import com.nexus.sion.feature.project.command.application.dto.FunctionScoreDTO;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DeveloperProjectWorkCommandServiceImpl implements DeveloperProjectWorkCommandService {
 
   private final DeveloperProjectWorkRepository workRepository;
@@ -31,6 +37,7 @@ public class DeveloperProjectWorkCommandServiceImpl implements DeveloperProjectW
   private final DeveloperProjectWorkHistoryTechStackRepository workHistoryTechStackRepository;
   private final NotificationCommandService notificationCommandService;
   private final MemberRepository memberRepository;
+  private final ProjectEvaluateCommandServiceImpl projectEvaluateCommandService;
 
   @Override
   @Transactional
@@ -42,7 +49,40 @@ public class DeveloperProjectWorkCommandServiceImpl implements DeveloperProjectW
             .orElseThrow(() -> new BusinessException(ErrorCode.WORK_HISTORY_NOT_FOUND));
     work.approve(adminId);
 
-    // 점수 산정 로직 코드
+    //점수 산정 로직 코드
+    List<DeveloperProjectWorkHistory> histories = workHistoryRepository.findAllByDeveloperProjectWorkId(work.getId());
+
+    List<Long> historyIds = histories.stream()
+            .map(DeveloperProjectWorkHistory::getId)
+            .toList();
+
+    List<DeveloperProjectWorkHistoryTechStack> techStacks = workHistoryTechStackRepository.findAllByDeveloperProjectWorkHistoryIdIn(historyIds);
+
+    Map<Long, List<String>> historyIdToStacksMap = techStacks.stream()
+            .collect(Collectors.groupingBy(
+                    DeveloperProjectWorkHistoryTechStack::getDeveloperProjectWorkHistoryId,
+                    Collectors.mapping(DeveloperProjectWorkHistoryTechStack::getTechStackName, Collectors.toList())
+            ));
+
+    List<FunctionScore> functionScores = histories.stream()
+            .map(history -> new FunctionScore(
+                    history.getFunctionName(),
+                    history.getFunctionDescription(),
+                    history.getFunctionType().name(),
+                    history.getDet(),
+                    history.getFtr(),
+                    historyIdToStacksMap.getOrDefault(history.getId(), List.of())
+            ))
+            .toList();
+
+    FunctionScoreDTO dto = new FunctionScoreDTO(
+            work.getEmployeeIdentificationNumber(),
+            work.getProjectCode(),
+            functionScores
+    );
+
+    projectEvaluateCommandService.evaluateFunctionScores(dto);
+
 
     // ===== 승인 알림 전송 =====
     String receiverId = work.getEmployeeIdentificationNumber(); // 요청한 사원

--- a/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/application/service/ProjectCommandServiceImpl.java
@@ -165,7 +165,7 @@ public class ProjectCommandServiceImpl implements ProjectCommandService {
             .orElseThrow(() -> new BusinessException(ErrorCode.PROJECT_NOT_FOUND));
 
     project.setStatus(status);
-    if (status == Project.ProjectStatus.COMPLETE) {
+    if (status == Project.ProjectStatus.EVALUATION) {
       project.setActualEndDate(LocalDate.now());
       createDeveloperProjectWorks(projectCode);
     } else {

--- a/src/main/java/com/nexus/sion/feature/project/command/domain/aggregate/DeveloperProjectWorkHistory.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/domain/aggregate/DeveloperProjectWorkHistory.java
@@ -12,6 +12,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@ToString
 public class DeveloperProjectWorkHistory extends BaseTimeEntity {
 
   @Id

--- a/src/main/java/com/nexus/sion/feature/project/command/domain/aggregate/Project.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/domain/aggregate/Project.java
@@ -69,7 +69,8 @@ public class Project extends BaseTimeEntity {
     WAITING,
     IN_PROGRESS,
     COMPLETE,
-    INCOMPLETE
+    INCOMPLETE,
+    EVALUATION
   }
 
   public enum AnalysisStatus {

--- a/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryRepository.java
@@ -4,5 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nexus.sion.feature.project.command.domain.aggregate.DeveloperProjectWorkHistory;
 
+import java.util.List;
+
 public interface DeveloperProjectWorkHistoryRepository
-    extends JpaRepository<DeveloperProjectWorkHistory, Long> {}
+    extends JpaRepository<DeveloperProjectWorkHistory, Long> {
+    List<DeveloperProjectWorkHistory> findAllByDeveloperProjectWorkId(Long id);
+}

--- a/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryTechStackRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryTechStackRepository.java
@@ -4,5 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nexus.sion.feature.project.command.domain.aggregate.DeveloperProjectWorkHistoryTechStack;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface DeveloperProjectWorkHistoryTechStackRepository
-    extends JpaRepository<DeveloperProjectWorkHistoryTechStack, Long> {}
+    extends JpaRepository<DeveloperProjectWorkHistoryTechStack, Long> {
+    List<DeveloperProjectWorkHistoryTechStack> findAllByDeveloperProjectWorkHistoryIdIn(List<Long> developerProjectWorkHistoryIds);
+}

--- a/src/main/java/com/nexus/sion/feature/squad/command/domain/service/SquadSelectorImpl.java
+++ b/src/main/java/com/nexus/sion/feature/squad/command/domain/service/SquadSelectorImpl.java
@@ -52,10 +52,10 @@ public class SquadSelectorImpl {
     double duration = durationScores.getOrDefault(squad, 0.0);
 
     // 기본 가중치
-    double techWeight = 0.1;
-    double domainWeight = 0.1;
-    double costWeight = 0.1;
-    double durationWeight = 0.1;
+    double techWeight = 0;
+    double domainWeight = 0;
+    double costWeight = 0;
+    double durationWeight = 0;
 
     // 선택 기준에 따라 특정 항목 가중치 조정
     switch (criteria) {

--- a/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
@@ -40,5 +40,6 @@ public class SquadDetailResponse {
     private int monthlyUnitPrice;
     private String memberId;
     private BigDecimal productivity;
+    private Byte isLeader;
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/dto/response/SquadDetailResponse.java
@@ -40,6 +40,6 @@ public class SquadDetailResponse {
     private int monthlyUnitPrice;
     private String memberId;
     private BigDecimal productivity;
-    private Byte isLeader;
+    private boolean isLeader;
   }
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -125,7 +125,8 @@ public class SquadQueryRepository {
                 MEMBER.GRADE_CODE,
                 GRADE.MONTHLY_UNIT_PRICE,
                 MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
-                GRADE.PRODUCTIVITY)
+                GRADE.PRODUCTIVITY,
+                        SQUAD_EMPLOYEE.IS_LEADER)
             .from(SQUAD_EMPLOYEE)
             .join(MEMBER)
             .on(
@@ -162,6 +163,7 @@ public class SquadQueryRepository {
                         .monthlyUnitPrice(r.get(GRADE.MONTHLY_UNIT_PRICE))
                         .memberId(r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
                         .productivity(r.get(GRADE.PRODUCTIVITY))
+                            .isLeader(r.get(SQUAD_EMPLOYEE.IS_LEADER))
                         .build())
             .toList();
 

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -163,7 +163,7 @@ public class SquadQueryRepository {
                         .monthlyUnitPrice(r.get(GRADE.MONTHLY_UNIT_PRICE))
                         .memberId(r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
                         .productivity(r.get(GRADE.PRODUCTIVITY))
-                            .isLeader(r.get(SQUAD_EMPLOYEE.IS_LEADER))
+                            .isLeader(r.get(SQUAD_EMPLOYEE.IS_LEADER) != null && r.get(SQUAD_EMPLOYEE.IS_LEADER) == 1)
                         .build())
             .toList();
 

--- a/target/generated-sources/jooq/com/example/jooq/generated/enums/ProjectStatus.java
+++ b/target/generated-sources/jooq/com/example/jooq/generated/enums/ProjectStatus.java
@@ -16,7 +16,9 @@ public enum ProjectStatus implements EnumType {
 
   COMPLETE("COMPLETE"),
 
-  INCOMPLETE("INCOMPLETE");
+  INCOMPLETE("INCOMPLETE"),
+
+  EVALUATION("EVALUATION");;
 
   private final String literal;
 


### PR DESCRIPTION
## 🪐 작업 내용
- 프로젝트 이력 승인 시 점수 산정 로직 연결 구현했습니다. 
- 프리랜서 외부 개발자로 등록 시 프리랜서 db에서 S3 url로 조회해서 점수 산정하는 로직 구현했습니다. 

## 📚 논의하고 싶은 내용 (선택)
- 선택사항


<br>

## ✅ 체크리스트
- [ ]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [ ]  spotless apply 적용 여부
      `./gradlew spotlessApply`
