### PR TITLE
[Refactor] 관리자 메인 대시보드 조회 변경

### DIFF
--- a/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/dto/response/DashboardSummaryResponse.java
@@ -2,6 +2,7 @@ package com.nexus.sion.feature.member.query.dto.response;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -10,7 +11,7 @@ import lombok.Builder;
 @Builder
 public record DashboardSummaryResponse(
     List<PendingProject> pendingProjects,
-    List<AnalyzingProject> analyzingProjects,
+    List<PendingApprovalProject> pendingApprovalProjects,
     List<TopDeveloper> topDevelopers,
     List<FreelancerSummary> freelancerTop5,
     DeveloperAvailability developerAvailability,
@@ -25,14 +26,22 @@ public record DashboardSummaryResponse(
       String domainName,
       LocalDate startDate) {}
 
-  public record AnalyzingProject(String id, String name, LocalDate analysisStartTime) {}
+  @Builder
+  public record PendingApprovalProject(
+          Long id,
+          String projectCode,
+          String projectTitle,
+          String developerId,
+          String developerName,
+          LocalDateTime createdAt
+  ) {}
 
   @Builder
   public record TopDeveloper(
       String id,
       String name,
       String grade,
-      BigDecimal productivity,
+      Integer totalScores,
       List<String> techStacks,
       String profileUrl) {}
 

--- a/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/query/service/MemberQueryServiceImpl.java
@@ -155,7 +155,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
   public DashboardSummaryResponse getDashboardSummary() {
     return new DashboardSummaryResponse(
         memberQueryRepository.findPendingProjects(),
-        memberQueryRepository.findAnalyzingProjects(),
+        memberQueryRepository.findPendingApprovalProjects(),
         memberQueryRepository.fetchTopDevelopers(),
         memberQueryRepository.fetchTopFreelancers(),
         memberQueryRepository.fetchDeveloperAvailability(),


### PR DESCRIPTION
## 🪐 작업 내용
- 관리자 메인 대시보드에서 분석중인 프로젝트 보여주기 조회에서 프로젝트 이력 승인 내역을 조회하는 것으로 변경

## ✅ 체크리스트
- [ ]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [ ]  spotless apply 적용 여부
      `./gradlew spotlessApply`
