### PR TITLE
[feat] 자격증 승인 시 개발자 점수 이력 갱신 기능 구현

### DIFF
--- a/src/main/java/com/nexus/sion/common/s3/service/DocumentS3Service.java
+++ b/src/main/java/com/nexus/sion/common/s3/service/DocumentS3Service.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.UUID;
-import java.net.URL;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -90,10 +90,10 @@ public class DocumentS3Service {
       if (!"application/pdf".equalsIgnoreCase(contentType)) {
         throw new IllegalArgumentException("PDF 파일만 다운로드할 수 있습니다.");
       }
-      
+
       File tempFile = Files.createTempFile("resume_", ".pdf").toFile();
       try (InputStream inputStream = connection.getInputStream();
-           FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+          FileOutputStream outputStream = new FileOutputStream(tempFile)) {
         byte[] buffer = new byte[8192];
         int bytesRead;
         while ((bytesRead = inputStream.read(buffer)) != -1) {

--- a/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/controller/FreelancerCommandController.java
@@ -2,7 +2,6 @@ package com.nexus.sion.feature.member.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.nexus.sion.common.dto.ApiResponse;
 import com.nexus.sion.feature.member.command.application.service.FreelancerCommandServiceImpl;
@@ -17,8 +16,7 @@ public class FreelancerCommandController {
   private final FreelancerCommandServiceImpl freelancerCommandService;
 
   @PostMapping("/{freelancerId}/register")
-  public ResponseEntity<ApiResponse<Void>> registerAsMember(
-      @PathVariable String freelancerId) {
+  public ResponseEntity<ApiResponse<Void>> registerAsMember(@PathVariable String freelancerId) {
     freelancerCommandService.registerFreelancerAsMember(freelancerId);
     return ResponseEntity.ok(ApiResponse.success(null));
   }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/AdminCertificateApprovalServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/AdminCertificateApprovalServiceImpl.java
@@ -8,7 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.nexus.sion.exception.BusinessException;
 import com.nexus.sion.exception.ErrorCode;
 import com.nexus.sion.feature.member.command.application.dto.request.CertificateRejectRequest;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.Certificate;
+import com.nexus.sion.feature.member.command.domain.aggregate.entity.MemberScoreHistory;
 import com.nexus.sion.feature.member.command.domain.aggregate.entity.UserCertificateHistory;
+import com.nexus.sion.feature.member.command.domain.repository.CertificateRepository;
+import com.nexus.sion.feature.member.command.domain.repository.MemberScoreHistoryRepository;
 import com.nexus.sion.feature.member.command.domain.repository.UserCertificateHistoryRepository;
 import com.nexus.sion.feature.member.query.dto.response.UserCertificateHistoryResponse;
 
@@ -19,33 +23,56 @@ import lombok.RequiredArgsConstructor;
 public class AdminCertificateApprovalServiceImpl implements AdminCertificateApprovalService {
 
   private final UserCertificateHistoryRepository userCertificateHistoryRepository;
+  private final CertificateRepository certificateRepository;
+  private final MemberScoreHistoryRepository memberScoreHistoryRepository;
 
   @Override
   @Transactional
   public List<UserCertificateHistoryResponse> getAllCertificates() {
     return userCertificateHistoryRepository.findAll().stream()
-        .map(UserCertificateHistoryResponse::fromEntity)
-        .toList();
+            .map(UserCertificateHistoryResponse::fromEntity)
+            .toList();
   }
 
   @Override
   @Transactional
   public void approveUserCertificate(Long id) {
-    UserCertificateHistory history =
-        userCertificateHistoryRepository
+    UserCertificateHistory history = userCertificateHistoryRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_CERTIFICATE_NOT_FOUND));
+
     history.approve();
     userCertificateHistoryRepository.save(history);
+
+    // 자격증 점수 가져오기
+    Certificate certificate = certificateRepository.findById(history.getCertificateName())
+            .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
+    int certificateScore = certificate.getScore();
+
+    String employeeId = history.getEmployeeIdentificationNumber();
+
+    // 기존 최신 점수 이력 조회
+    MemberScoreHistory latest = memberScoreHistoryRepository
+            .findTopByEmployeeIdentificationNumberOrderByCreatedAtDesc(employeeId)
+            .orElseGet(() -> MemberScoreHistory.initial(employeeId));
+
+    // 새로운 점수 이력 저장
+    MemberScoreHistory newHistory = MemberScoreHistory.builder()
+            .employeeIdentificationNumber(employeeId)
+            .totalTechStackScores(latest.getTotalTechStackScores())
+            .totalCertificateScores(latest.getTotalCertificateScores() + certificateScore)
+            .build();
+
+    memberScoreHistoryRepository.save(newHistory);
   }
 
   @Override
   @Transactional
   public void rejectUserCertificate(Long id, CertificateRejectRequest request) {
-    UserCertificateHistory history =
-        userCertificateHistoryRepository
+    UserCertificateHistory history = userCertificateHistoryRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_CERTIFICATE_NOT_FOUND));
+
     history.reject(request.getRejectedReason());
     userCertificateHistoryRepository.save(history);
   }

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/AdminCertificateApprovalServiceImpl.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/AdminCertificateApprovalServiceImpl.java
@@ -30,14 +30,15 @@ public class AdminCertificateApprovalServiceImpl implements AdminCertificateAppr
   @Transactional
   public List<UserCertificateHistoryResponse> getAllCertificates() {
     return userCertificateHistoryRepository.findAll().stream()
-            .map(UserCertificateHistoryResponse::fromEntity)
-            .toList();
+        .map(UserCertificateHistoryResponse::fromEntity)
+        .toList();
   }
 
   @Override
   @Transactional
   public void approveUserCertificate(Long id) {
-    UserCertificateHistory history = userCertificateHistoryRepository
+    UserCertificateHistory history =
+        userCertificateHistoryRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_CERTIFICATE_NOT_FOUND));
 
@@ -45,19 +46,23 @@ public class AdminCertificateApprovalServiceImpl implements AdminCertificateAppr
     userCertificateHistoryRepository.save(history);
 
     // 자격증 점수 가져오기
-    Certificate certificate = certificateRepository.findById(history.getCertificateName())
+    Certificate certificate =
+        certificateRepository
+            .findById(history.getCertificateName())
             .orElseThrow(() -> new BusinessException(ErrorCode.CERTIFICATE_NOT_FOUND));
     int certificateScore = certificate.getScore();
 
     String employeeId = history.getEmployeeIdentificationNumber();
 
     // 기존 최신 점수 이력 조회
-    MemberScoreHistory latest = memberScoreHistoryRepository
+    MemberScoreHistory latest =
+        memberScoreHistoryRepository
             .findTopByEmployeeIdentificationNumberOrderByCreatedAtDesc(employeeId)
             .orElseGet(() -> MemberScoreHistory.initial(employeeId));
 
     // 새로운 점수 이력 저장
-    MemberScoreHistory newHistory = MemberScoreHistory.builder()
+    MemberScoreHistory newHistory =
+        MemberScoreHistory.builder()
             .employeeIdentificationNumber(employeeId)
             .totalTechStackScores(latest.getTotalTechStackScores())
             .totalCertificateScores(latest.getTotalCertificateScores() + certificateScore)
@@ -69,7 +74,8 @@ public class AdminCertificateApprovalServiceImpl implements AdminCertificateAppr
   @Override
   @Transactional
   public void rejectUserCertificate(Long id, CertificateRejectRequest request) {
-    UserCertificateHistory history = userCertificateHistoryRepository
+    UserCertificateHistory history =
+        userCertificateHistoryRepository
             .findById(id)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_CERTIFICATE_NOT_FOUND));
 

--- a/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/application/service/FreelancerCommandService.java
@@ -1,6 +1,5 @@
 package com.nexus.sion.feature.member.command.application.service;
 
-
 public interface FreelancerCommandService {
   void registerFreelancerAsMember(String freelancerId);
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/MemberScoreHistory.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/MemberScoreHistory.java
@@ -31,9 +31,9 @@ public class MemberScoreHistory extends BaseTimeEntity {
 
   public static MemberScoreHistory initial(String employeeId) {
     return MemberScoreHistory.builder()
-            .employeeIdentificationNumber(employeeId)
-            .totalTechStackScores(0)
-            .totalCertificateScores(0)
-            .build();
+        .employeeIdentificationNumber(employeeId)
+        .totalTechStackScores(0)
+        .totalCertificateScores(0)
+        .build();
   }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/MemberScoreHistory.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/MemberScoreHistory.java
@@ -28,4 +28,12 @@ public class MemberScoreHistory extends BaseTimeEntity {
 
   @Column(name = "total_certificate_scores", nullable = false)
   private int totalCertificateScores;
+
+  public static MemberScoreHistory initial(String employeeId) {
+    return MemberScoreHistory.builder()
+            .employeeIdentificationNumber(employeeId)
+            .totalTechStackScores(0)
+            .totalCertificateScores(0)
+            .build();
+  }
 }

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/TrainingRecommendation.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/aggregate/entity/TrainingRecommendation.java
@@ -10,7 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import lombok.*;
 
 @Entity
-@Table(name = "training_program")
+@Table(name = "training_recommendation")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberScoreHistoryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberScoreHistoryRepository.java
@@ -11,6 +11,6 @@ public interface MemberScoreHistoryRepository extends JpaRepository<MemberScoreH
   Optional<MemberScoreHistory> findByEmployeeIdentificationNumber(
       String employeeIdentificationNumber);
 
-  Optional<MemberScoreHistory> findTopByEmployeeIdentificationNumberOrderByCreatedAtDesc(String employeeIdentificationNumber);
+  Optional<MemberScoreHistory> findTopByEmployeeIdentificationNumberOrderByCreatedAtDesc(
+      String employeeIdentificationNumber);
 }
-

--- a/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberScoreHistoryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/member/command/domain/repository/MemberScoreHistoryRepository.java
@@ -10,4 +10,7 @@ public interface MemberScoreHistoryRepository extends JpaRepository<MemberScoreH
 
   Optional<MemberScoreHistory> findByEmployeeIdentificationNumber(
       String employeeIdentificationNumber);
+
+  Optional<MemberScoreHistory> findTopByEmployeeIdentificationNumberOrderByCreatedAtDesc(String employeeIdentificationNumber);
 }
+

--- a/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryRepository.java
@@ -1,12 +1,12 @@
 package com.nexus.sion.feature.project.command.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nexus.sion.feature.project.command.domain.aggregate.DeveloperProjectWorkHistory;
 
-import java.util.List;
-
 public interface DeveloperProjectWorkHistoryRepository
     extends JpaRepository<DeveloperProjectWorkHistory, Long> {
-    List<DeveloperProjectWorkHistory> findAllByDeveloperProjectWorkId(Long id);
+  List<DeveloperProjectWorkHistory> findAllByDeveloperProjectWorkId(Long id);
 }

--- a/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryTechStackRepository.java
+++ b/src/main/java/com/nexus/sion/feature/project/command/repository/DeveloperProjectWorkHistoryTechStackRepository.java
@@ -1,13 +1,13 @@
 package com.nexus.sion.feature.project.command.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nexus.sion.feature.project.command.domain.aggregate.DeveloperProjectWorkHistoryTechStack;
 
-import java.util.Collection;
-import java.util.List;
-
 public interface DeveloperProjectWorkHistoryTechStackRepository
     extends JpaRepository<DeveloperProjectWorkHistoryTechStack, Long> {
-    List<DeveloperProjectWorkHistoryTechStack> findAllByDeveloperProjectWorkHistoryIdIn(List<Long> developerProjectWorkHistoryIds);
+  List<DeveloperProjectWorkHistoryTechStack> findAllByDeveloperProjectWorkHistoryIdIn(
+      List<Long> developerProjectWorkHistoryIds);
 }

--- a/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
+++ b/src/main/java/com/nexus/sion/feature/squad/query/repository/SquadQueryRepository.java
@@ -126,7 +126,7 @@ public class SquadQueryRepository {
                 GRADE.MONTHLY_UNIT_PRICE,
                 MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER,
                 GRADE.PRODUCTIVITY,
-                        SQUAD_EMPLOYEE.IS_LEADER)
+                SQUAD_EMPLOYEE.IS_LEADER)
             .from(SQUAD_EMPLOYEE)
             .join(MEMBER)
             .on(
@@ -163,7 +163,9 @@ public class SquadQueryRepository {
                         .monthlyUnitPrice(r.get(GRADE.MONTHLY_UNIT_PRICE))
                         .memberId(r.get(MEMBER.EMPLOYEE_IDENTIFICATION_NUMBER))
                         .productivity(r.get(GRADE.PRODUCTIVITY))
-                            .isLeader(r.get(SQUAD_EMPLOYEE.IS_LEADER) != null && r.get(SQUAD_EMPLOYEE.IS_LEADER) == 1)
+                        .isLeader(
+                            r.get(SQUAD_EMPLOYEE.IS_LEADER) != null
+                                && r.get(SQUAD_EMPLOYEE.IS_LEADER) == 1)
                         .build())
             .toList();
 

--- a/target/generated-sources/jooq/com/example/jooq/generated/enums/ProjectStatus.java
+++ b/target/generated-sources/jooq/com/example/jooq/generated/enums/ProjectStatus.java
@@ -18,7 +18,8 @@ public enum ProjectStatus implements EnumType {
 
   INCOMPLETE("INCOMPLETE"),
 
-  EVALUATION("EVALUATION");;
+  EVALUATION("EVALUATION");
+  ;
 
   private final String literal;
 


### PR DESCRIPTION
## 🛰️ Issue
Closes #341 


<br>

## 🪐 작업 내용
자격증 승인 시 점수 이력 자동 반영 기능 구현
개발자 자격증 승인 후 점수 이력 테이블에 누적 저장 처리
자격증 점수를 member_score_history에 반영하는 로직 추가


<br>

## ✅ 체크리스트
- [x]  기능 구현
- [ ]  service mock 단위 테스트
- [ ]  spring mvc 통합 테스트
- [x]  spotless apply 적용 여부
      `./gradlew spotlessApply`
