### PR TITLE
[chore] docker build시 timezone 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=build /app/build/libs/*.jar ./
 RUN mv $(ls *.jar | grep -v plain) app.jar
 
 EXPOSE 8000
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]


### PR DESCRIPTION
## 🪐 작업 내용
배포환경에서 시간대가 이상하게 설정되는 버그가있어서
해결을 위해서 dockerfile을 수정했습니다

<br>

## ✅ 체크리스트
- [x]  기능 구현

